### PR TITLE
Follow-up: make FPS correction mapping and CFR mode explicit

### DIFF
--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -209,7 +209,9 @@ find "$original_video_base_path" -maxdepth 1 -type f -name "*.$video_extension" 
       -y \
       -i "$video_path" \
       -filter:v fps="$target_fps" \
-      $(if [[ $no_audio == TRUE ]]; then echo "-an"; fi) \
+      -fps_mode:v cfr \
+      -map 0:v \
+      $(if [[ $no_audio != TRUE ]]; then echo "-map 0:a?"; else echo "-an"; fi) \
       "$fixed_video_path"
     log INFO "fixed video path: $(ansi "$YELLOW" "$fixed_video_path")"
 


### PR DESCRIPTION
### Motivation
- Make the FPS-fixing `ffmpeg` invocation deterministic by explicitly selecting streams and forcing a constant frame rate (CFR) to avoid A/V sync issues on variable-FPS inputs. 
- Address reviewer feedback to avoid implicit stream selection and to keep audio handling explicit without forcing a particular audio codec.

### Description
- Added `-fps_mode:v cfr` to the FPS-correction `ffmpeg` command to force constant frame rate output. 
- Added `-map 0:v` to explicitly select input video streams. 
- Reworked audio handling so audio is explicitly mapped with `-map 0:a?` when enabled and `-an` when `--no-audio` is set.

### Testing
- Performed a shell syntax check with `bash -n fps_fixer.bash`, which completed successfully. 
- No runtime `ffmpeg` transcode tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91300d32c832b918e9ce93676b1c0)

Issue: #3