### PR TITLE
Use shared decimal regex for FPS extraction and speed-factor validation

### DIFF
--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -35,8 +35,7 @@ function log() {
     1>&2
 }
 
-# NOTE: keep this regex core compatible with Bash ERE (the strictest engine used in this script).
-# Avoid PCRE-only features (e.g. lookarounds, \d, non-capturing groups, etc.).
+# keep this regex core compatible with Bash ERE (the strictest engine used in this script)
 declare -r DECIMAL_NUMBER_REGEX_CORE='[0-9]+([.,][0-9]+)?'
 
 function get_fps() {

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -35,11 +35,15 @@ function log() {
     1>&2
 }
 
+# NOTE: keep this regex core compatible with Bash ERE (the strictest engine used in this script).
+# Avoid PCRE-only features (e.g. lookarounds, \d, non-capturing groups, etc.).
+declare -r DECIMAL_NUMBER_REGEX_CORE='[0-9]+([.,][0-9]+)?'
+
 function get_fps() {
   declare -r file_path="$1"
 
   ffmpeg -i "$file_path" 2>&1 \
-    | grep --perl-regexp --only-matching "\d+([.,]\d+)?\s*(?=fps)" \
+    | grep --perl-regexp --only-matching "$DECIMAL_NUMBER_REGEX_CORE\s*(?=fps)" \
     | sed --regexp-extended "s/\s*$//" \
     | head --lines 1 \
     | sed "s/,/./"
@@ -162,10 +166,12 @@ if [[ $no_process != TRUE ]]; then
 fi
 
 if [[ -n "$speed_factor" ]]; then
-  if ! [[ "$speed_factor" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  if ! [[ "$speed_factor" =~ ^$DECIMAL_NUMBER_REGEX_CORE$ ]]; then
     log ERROR "incorrect speed factor: should be a floating-point number"
     exit 1
   fi
+
+  speed_factor="${speed_factor/,/.}"
 
   if (( "$(bc <<< "$speed_factor < 0.5 || $speed_factor > 2.0")" )); then
     log ERROR "incorrect speed factor: should be in the range [0.5; 2.0]"

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -35,14 +35,14 @@ function log() {
     1>&2
 }
 
-# keep this regex core compatible with Bash ERE (the strictest engine used in this script)
-declare -r DECIMAL_NUMBER_REGEX_CORE='[0-9]+([.,][0-9]+)?'
+# keep this regexp compatible with Bash ERE (the strictest engine used in this script)
+declare -r DECIMAL_NUMBER_REGEXP='[0-9]+([.,][0-9]+)?'
 
 function get_fps() {
   declare -r file_path="$1"
 
   ffmpeg -i "$file_path" 2>&1 \
-    | grep --perl-regexp --only-matching "$DECIMAL_NUMBER_REGEX_CORE\s*(?=fps)" \
+    | grep --perl-regexp --only-matching "$DECIMAL_NUMBER_REGEXP\s*(?=fps)" \
     | sed --regexp-extended "s/\s*$//" \
     | head --lines 1 \
     | sed "s/,/./"
@@ -165,7 +165,7 @@ if [[ $no_process != TRUE ]]; then
 fi
 
 if [[ -n "$speed_factor" ]]; then
-  if ! [[ "$speed_factor" =~ ^$DECIMAL_NUMBER_REGEX_CORE$ ]]; then
+  if ! [[ "$speed_factor" =~ ^$DECIMAL_NUMBER_REGEXP$ ]]; then
     log ERROR "incorrect speed factor: should be a floating-point number"
     exit 1
   fi

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -7,6 +7,9 @@ declare -r YELLOW="$(tput setaf 3)"
 declare -r MAGENTA="$(tput setaf 4)"
 declare -r RESET="$(tput sgr0)"
 
+# keep this regexp compatible with Bash ERE (the strictest engine used in this script)
+declare -r DECIMAL_NUMBER_REGEXP='[0-9]+([.,][0-9]+)?'
+
 function ansi() {
   declare -r code="$1"
   declare -r text="$2"
@@ -34,9 +37,6 @@ function log() {
     "$message" \
     1>&2
 }
-
-# keep this regexp compatible with Bash ERE (the strictest engine used in this script)
-declare -r DECIMAL_NUMBER_REGEXP='[0-9]+([.,][0-9]+)?'
 
 function get_fps() {
   declare -r file_path="$1"


### PR DESCRIPTION
### Motivation
- Make numeric parsing consistent and portable across shells by centralizing the decimal-number regex and avoiding PCRE-only features. 
- Improve reliability of FPS extraction from `ffmpeg` output and of the `--speed-factor` validation and normalization.

### Description
- Introduces `DECIMAL_NUMBER_REGEX_CORE` and documents the compatibility constraint with Bash ERE. 
- Uses `DECIMAL_NUMBER_REGEX_CORE` in `get_fps` to extract FPS via `grep` instead of an inline regex. 
- Replaces the inline `speed_factor` validation regex with `DECIMAL_NUMBER_REGEX_CORE` and normalizes comma decimals to dot early via `speed_factor="${speed_factor/,/.}"`. 
- Minor formatting and comment additions to clarify intent and ensure portability.

### Testing
- No automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3b25a93c832ba2495c72437bb5c6)