### PR TITLE
Treat FPS tolerance as closed interval and add --force option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options:
 - `-b PATH`, `--base-path PATH` &mdash; base path for fixed videos (should be relative to argument `<path>`; default: `./fixed-videos`);
 - `-f FPS`, `--fps FPS` &mdash; target FPS (default: `60`);
 - `-E EPSILON`, `--epsilon EPSILON` &mdash; allowable error when comparing FPS (default: `2`);
+- `-F`, `--force` &mdash; process every video regardless of FPS check;
 - `-s SPEED`, `--speed-factor SPEED` &mdash; optional acceleration speed factor between `0.5` and `2.0` (inclusive);
 - `--no-audio` &mdash; remove audio from output videos;
 - `--no-process` &mdash; don't process videos, only search for them and check their FPS.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The utility for fixing FPS in videos.
   - optional removal of audio from output videos;
 - automatic directory creation for fixed videos;
 - the mode without real processing of videos, only with search of them and check of their FPS;
+- the mode with processing every video regardless of FPS check;
 - logging:
   - logging of a video name and FPS at the beginning of processing;
   - logging of a fixed video path at the end of processing.

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -52,11 +52,12 @@ function is_target_fps() {
   declare -r fps="$1"
   declare -r target_fps="$2"
   declare -r epsilon="$3"
+  declare -r floating_point_tolerance="0.000001"
 
   bc <<< "
     define abs(value) { if (value > 0) { return value; } else { return -value; } }
 
-    abs($fps - $target_fps) < $epsilon
+    abs($fps - $target_fps) <= ($epsilon + $floating_point_tolerance)
   "
 }
 
@@ -68,7 +69,7 @@ options="$(
   getopt \
     --name "$script_name" \
     --options "vhe:b:f:E:s:" \
-    --longoptions "version,help,extension:,base-path:,fps:,epsilon:,speed-factor:,no-audio,no-process" \
+    --longoptions "version,help,extension:,base-path:,fps:,epsilon:,speed-factor:,no-audio,no-process,force" \
     -- "$@"
 )"
 if [[ $? != 0 ]]; then
@@ -83,6 +84,7 @@ declare fps_epsilon="2"
 declare speed_factor=""
 declare no_audio=FALSE
 declare no_process=FALSE
+declare force=FALSE
 eval set -- "$options"
 while [[ "$1" != "--" ]]; do
   case "$1" in
@@ -112,6 +114,7 @@ while [[ "$1" != "--" ]]; do
       echo "  --no-audio                           - remove audio from output videos;"
       echo "  --no-process                         - don't process videos," \
         "only search for them and check their FPS."
+      echo "  --force                              - process every video regardless of FPS check."
       echo
       echo "Arguments:"
       echo "  <path>                               - base path to original videos" \
@@ -144,6 +147,9 @@ while [[ "$1" != "--" ]]; do
       ;;
     "--no-process")
       no_process=TRUE
+      ;;
+    "--force")
+      force=TRUE
       ;;
   esac
 
@@ -194,7 +200,7 @@ find "$original_video_base_path" -maxdepth 1 -type f -name "*.$video_extension" 
 
     log INFO "video $(ansi "$YELLOW" "$video_path") has $(ansi "$MAGENTA" "$video_fps") FPS"
 
-    if (( "$(is_target_fps "$video_fps" "$target_fps" "$fps_epsilon")" )); then
+    if [[ $force != TRUE ]] && (( "$(is_target_fps "$video_fps" "$target_fps" "$fps_epsilon")" )); then
       log INFO "video $(ansi "$YELLOW" "$video_path") already has the target FPS"
       continue
     fi

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -206,7 +206,7 @@ find "$original_video_base_path" -maxdepth 1 -type f -name "*.$video_extension" 
         continue
       fi
     else
-      log INFO "force processing is enabled; skip FPS check for video $(ansi "$YELLOW" "$video_path")"
+      log WARNING "force processing is enabled; skip FPS check for video $(ansi "$YELLOW" "$video_path")"
     fi
 
     if [[ $no_process == TRUE ]]; then

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -69,7 +69,7 @@ options="$(
   getopt \
     --name "$script_name" \
     --options "vhe:b:f:E:Fs:" \
-    --longoptions "version,help,extension:,base-path:,fps:,epsilon:,speed-factor:,no-audio,no-process,force" \
+    --longoptions "version,help,extension:,base-path:,fps:,epsilon:,force,speed-factor:,no-audio,no-process" \
     -- "$@"
 )"
 if [[ $? != 0 ]]; then
@@ -81,10 +81,10 @@ declare video_extension="mp4"
 declare fixed_video_base_path="./fixed-videos"
 declare target_fps="60"
 declare fps_epsilon="2"
+declare force_processing=FALSE
 declare speed_factor=""
 declare no_audio=FALSE
 declare no_process=FALSE
-declare force=FALSE
 eval set -- "$options"
 while [[ "$1" != "--" ]]; do
   case "$1" in
@@ -139,7 +139,7 @@ while [[ "$1" != "--" ]]; do
       shift # an additional shift for the option parameter
       ;;
     "-F" | "--force")
-      force=TRUE
+      force_processing=TRUE
       ;;
     "-s" | "--speed-factor")
       speed_factor="$2"
@@ -192,19 +192,21 @@ find "$original_video_base_path" -maxdepth 1 -type f -name "*.$video_extension" 
     declare video_path="$REPLY"
     log INFO "process video $(ansi "$YELLOW" "$video_path")"
 
-    declare video_fps="$(get_fps "$video_path")"
-    if [[ -z "$video_fps" ]]; then
-      log WARNING "unable to extract FPS from video $(ansi "$YELLOW" "$video_path")"
-      continue
-    fi
+    if [[ $force_processing != TRUE ]]; then
+      declare video_fps="$(get_fps "$video_path")"
+      if [[ -z "$video_fps" ]]; then
+        log WARNING "unable to extract FPS from video $(ansi "$YELLOW" "$video_path")"
+        continue
+      fi
 
-    log INFO "video $(ansi "$YELLOW" "$video_path") has $(ansi "$MAGENTA" "$video_fps") FPS"
+      log INFO "video $(ansi "$YELLOW" "$video_path") has $(ansi "$MAGENTA" "$video_fps") FPS"
 
-    if [[ $force != TRUE ]]; then
       if (( "$(is_target_fps "$video_fps" "$target_fps" "$fps_epsilon")" )); then
         log INFO "video $(ansi "$YELLOW" "$video_path") already has the target FPS"
         continue
       fi
+    else
+      log INFO "force processing is enabled; skip FPS check for video $(ansi "$YELLOW" "$video_path")"
     fi
 
     if [[ $no_process == TRUE ]]; then

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -9,6 +9,7 @@ declare -r RESET="$(tput sgr0)"
 
 # keep this regexp compatible with Bash ERE (the strictest engine used in this script)
 declare -r DECIMAL_NUMBER_REGEXP='[0-9]+([.,][0-9]+)?'
+declare -r FLOATING_POINT_TOLERANCE="0.000001"
 
 function ansi() {
   declare -r code="$1"
@@ -52,12 +53,11 @@ function is_target_fps() {
   declare -r fps="$1"
   declare -r target_fps="$2"
   declare -r epsilon="$3"
-  declare -r floating_point_tolerance="0.000001"
 
   bc <<< "
     define abs(value) { if (value > 0) { return value; } else { return -value; } }
 
-    abs($fps - $target_fps) <= ($epsilon + $floating_point_tolerance)
+    abs($fps - $target_fps) <= ($epsilon + $FLOATING_POINT_TOLERANCE)
   "
 }
 
@@ -68,7 +68,7 @@ declare options
 options="$(
   getopt \
     --name "$script_name" \
-    --options "vhe:b:f:E:s:" \
+    --options "vhe:b:f:E:Fs:" \
     --longoptions "version,help,extension:,base-path:,fps:,epsilon:,speed-factor:,no-audio,no-process,force" \
     -- "$@"
 )"
@@ -109,12 +109,12 @@ while [[ "$1" != "--" ]]; do
       echo "  -f FPS, --fps FPS                    - target FPS (default: \"60\");"
       echo "  -E EPSILON, --epsilon EPSILON        - allowable error when comparing FPS" \
         "(default: \"2\");"
+      echo "  -F, --force                          - process every video regardless of FPS check;"
       echo "  -s SPEED, --speed-factor SPEED       - optional acceleration speed factor" \
         "between 0.5 and 2.0 (inclusive);"
       echo "  --no-audio                           - remove audio from output videos;"
       echo "  --no-process                         - don't process videos," \
         "only search for them and check their FPS."
-      echo "  --force                              - process every video regardless of FPS check."
       echo
       echo "Arguments:"
       echo "  <path>                               - base path to original videos" \
@@ -138,6 +138,9 @@ while [[ "$1" != "--" ]]; do
       fps_epsilon="$2"
       shift # an additional shift for the option parameter
       ;;
+    "-F" | "--force")
+      force=TRUE
+      ;;
     "-s" | "--speed-factor")
       speed_factor="$2"
       shift # an additional shift for the option parameter
@@ -147,9 +150,6 @@ while [[ "$1" != "--" ]]; do
       ;;
     "--no-process")
       no_process=TRUE
-      ;;
-    "--force")
-      force=TRUE
       ;;
   esac
 
@@ -200,9 +200,11 @@ find "$original_video_base_path" -maxdepth 1 -type f -name "*.$video_extension" 
 
     log INFO "video $(ansi "$YELLOW" "$video_path") has $(ansi "$MAGENTA" "$video_fps") FPS"
 
-    if [[ $force != TRUE ]] && (( "$(is_target_fps "$video_fps" "$target_fps" "$fps_epsilon")" )); then
-      log INFO "video $(ansi "$YELLOW" "$video_path") already has the target FPS"
-      continue
+    if [[ $force != TRUE ]]; then
+      if (( "$(is_target_fps "$video_fps" "$target_fps" "$fps_epsilon")" )); then
+        log INFO "video $(ansi "$YELLOW" "$video_path") already has the target FPS"
+        continue
+      fi
     fi
 
     if [[ $no_process == TRUE ]]; then


### PR DESCRIPTION
### Motivation

- The FPS check used a strict comparison which treats boundary values (e.g. target 60, epsilon 2, observed 58) as out-of-range and is surprising to users. 
- Floating-point extraction and `bc` calculations can produce borderline failures due to tiny precision errors. 
- Users sometimes want to always reprocess videos (previously done by setting `epsilon=0`), which is a non-obvious UX workaround.

### Description

- Change `is_target_fps` to treat the tolerance as a closed interval by using `<=` instead of `<` and add a small `floating_point_tolerance` of `1e-6` to mitigate FP edge cases. 
- Introduce a new `--force` CLI flag (parsed via `getopt`) and a `force` variable defaulting to `FALSE`. 
- Skip the FPS-matching early `continue` when `--force` is provided so videos are processed regardless of FPS. 
- Update the help text to document the new `--force` option.

### Testing

- Ran `bash -n fps_fixer.bash` to validate syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff179a4740832bbf9db54bb2e7a1a9)