### PR TITLE
Split speed-factor validation into dedicated Bats test cases

### DIFF
--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -49,13 +49,47 @@ teardown() {
   [ "$status" -eq 1 ]
 }
 
-@test "speed-factor validation works" {
+@test "--speed-factor abc fails because the value is not numeric" {
   run "$SCRIPT" --speed-factor abc
   [ "$status" -eq 1 ]
+}
 
+@test "--speed-factor 0.49 fails because it is below the allowed range" {
   run "$SCRIPT" --speed-factor 0.49
   [ "$status" -eq 1 ]
+}
 
+@test "--speed-factor 0.5 succeeds" {
+  run "$SCRIPT" --speed-factor 0.5 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+}
+
+@test "--speed-factor 1.5 succeeds" {
+  run "$SCRIPT" --speed-factor 1.5 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+}
+
+@test "--speed-factor 2.0 succeeds" {
+  run "$SCRIPT" --speed-factor 2.0 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+}
+
+@test "--speed-factor 2.01 fails because it is above the allowed range" {
+  run "$SCRIPT" --speed-factor 2.01
+  [ "$status" -eq 1 ]
+}
+
+@test "--speed-factor 2 succeeds" {
+  run "$SCRIPT" --speed-factor 2 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+}
+
+@test "--speed-factor .5 fails because a leading digit is required" {
+  run "$SCRIPT" --speed-factor .5
+  [ "$status" -eq 1 ]
+}
+
+@test "--speed-factor 1,5 succeeds" {
   run "$SCRIPT" --speed-factor 1,5 --no-process "$TMPDIR_TEST"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
### Motivation
- The original aggregated test for `--speed-factor` omitted several specified edge cases and combined multiple scenarios into a single test.  
- Each scenario needs to be an independent test so failures are isolated and easier to diagnose.

### Description
- Replaced the single `speed-factor validation works` test with separate `@test` cases in `test/fps_fixer.bats`, one per scenario.  
- Added explicit tests covering `abc`, `0.49`, `0.5`, `1.5`, `2.0`, `2.01`, `2`, `.5`, and `1,5` as requested.  
- Success-path tests run with `--no-process "$TMPDIR_TEST"` and error-path tests assert a non-zero status code.

### Testing
- Attempted to run the focused Bats tests with `bats test/fps_fixer.bats -f "--speed-factor"`, but the `bats` binary is not available in this environment so the run failed with `command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078f28b190832b851aace961ee06d5)

Issue: #12 