### PR TITLE
Fix hidden Unicode whitespace in discovery test assertions

### DIFF
--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -136,8 +136,8 @@ teardown() {
   ! grep -F -- "-i $TMPDIR_TEST/in/b.mov" "$FFMPEG_LOG_FILE"
   ! grep -F -- "-i $TMPDIR_TEST/in/fake.mp4" "$FFMPEG_LOG_FILE"
   ! grep -F -- "-i $TMPDIR_TEST/in/video.MP4" "$FFMPEG_LOG_FILE"
-  ! grep -F -- "-i $TMPDIR_TEST/in/video" "$FFMPEG_LOG_FILE"
-  ! grep -F -- "-i $TMPDIR_TEST/in/video.mp4.backup" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "-i $TMPDIR_TEST/in/video" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "-i $TMPDIR_TEST/in/video.mp4.backup" "$FFMPEG_LOG_FILE"
   ! grep -F -- "-i $TMPDIR_TEST/in/sub/c.mp4" "$FFMPEG_LOG_FILE"
 }
 


### PR DESCRIPTION
### Motivation
- Tests were failing because two `! grep` negation lines in `test/fps_fixer.bats` contained an invisible non‑breaking space (Unicode NBSP) which caused the shell to parse an empty/invalid command and produce `command not found` (exit 127). 

### Description
- Replaced the hidden NBSP bytes (`0xC2 0xA0`) with plain ASCII spaces on the two problematic lines containing `! grep` in `test/fps_fixer.bats` so Bats treats them as proper negated assertions. 

### Testing
- Verified the problematic bytes were removed using `sed -n '136,141p' test/fps_fixer.bats | od -An -t x1 -c` and by running a targeted `perl -CS -i -pe 's/\x{00A0}/ /g' test/fps_fixer.bats` transformation. 
- Attempted to run the test suite with `bats test/fps_fixer.bats` but it could not be executed in this environment because `bats` is not installed (`/bin/bash: bats: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b384edfe0832bac2b165aa2b4fc9a)

Issue: #12