### PR TITLE
test: consolidate and extend fps_fixer.bats option and speed-factor tests

### DIFF
--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -15,25 +15,21 @@ teardown() {
   rm -rf "$TMPDIR_TEST"
 }
 
-@test "-v exits 0" {
+@test "-v and --version exit 0" {
   run "$SCRIPT" -v
   [ "$status" -eq 0 ]
   [[ "$output" == *"FPS Fixer, v1.1.0"* ]]
-}
 
-@test "--version exits 0" {
   run "$SCRIPT" --version
   [ "$status" -eq 0 ]
   [[ "$output" == *"FPS Fixer, v1.1.0"* ]]
 }
 
-@test "-h exits 0" {
+@test "-h and --help exit 0" {
   run "$SCRIPT" -h
   [ "$status" -eq 0 ]
   [[ "$output" == *"Usage:"* ]]
-}
 
-@test "--help exits 0" {
   run "$SCRIPT" --help
   [ "$status" -eq 0 ]
   [[ "$output" == *"Usage:"* ]]
@@ -49,57 +45,66 @@ teardown() {
   [ "$status" -eq 1 ]
 }
 
-@test "--s abc fails because the value is not numeric" {
-  run "$SCRIPT" --s abc
+@test "-s and --speed-factor abc fail because the value is not numeric" {
+  run "$SCRIPT" -s abc
   [ "$status" -eq 1 ]
-}
 
-@test "--speed-factor abc fails because the value is not numeric" {
   run "$SCRIPT" --speed-factor abc
   [ "$status" -eq 1 ]
 }
 
-@test "--speed-factor 0.49 fails because it is below the allowed range" {
+@test "-s and --speed-factor 0.49 fail because it is below the allowed range" {
+  run "$SCRIPT" -s 0.49
+  [ "$status" -eq 1 ]
+
   run "$SCRIPT" --speed-factor 0.49
   [ "$status" -eq 1 ]
 }
 
-@test "-s 0.5 succeeds" {
-  run "$SCRIPT" -s 0.5 --no-process "$TMPDIR_TEST"
-  [ "$status" -eq 0 ]
-}
+@test "-s and --speed-factor 2.01 fail because it is above the allowed range" {
+  run "$SCRIPT" -s 2.01
+  [ "$status" -eq 1 ]
 
-@test "--speed-factor 0.5 succeeds" {
-  run "$SCRIPT" --speed-factor 0.5 --no-process "$TMPDIR_TEST"
-  [ "$status" -eq 0 ]
-}
-
-@test "--speed-factor 1.5 succeeds" {
-  run "$SCRIPT" --speed-factor 1.5 --no-process "$TMPDIR_TEST"
-  [ "$status" -eq 0 ]
-}
-
-@test "--speed-factor 2.0 succeeds" {
-  run "$SCRIPT" --speed-factor 2.0 --no-process "$TMPDIR_TEST"
-  [ "$status" -eq 0 ]
-}
-
-@test "--speed-factor 2.01 fails because it is above the allowed range" {
   run "$SCRIPT" --speed-factor 2.01
   [ "$status" -eq 1 ]
 }
 
-@test "--speed-factor 2 succeeds" {
-  run "$SCRIPT" --speed-factor 2 --no-process "$TMPDIR_TEST"
-  [ "$status" -eq 0 ]
-}
+@test "-s and --speed-factor .5 fail because a leading digit is required" {
+  run "$SCRIPT" -s .5
+  [ "$status" -eq 1 ]
 
-@test "--speed-factor .5 fails because a leading digit is required" {
   run "$SCRIPT" --speed-factor .5
   [ "$status" -eq 1 ]
 }
 
-@test "--speed-factor 1,5 succeeds" {
+@test "-s and --speed-factor successful values pass in no-process mode" {
+  run "$SCRIPT" -s 0.5 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+
+  run "$SCRIPT" --speed-factor 0.5 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+
+  run "$SCRIPT" -s 1.5 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+
+  run "$SCRIPT" --speed-factor 1.5 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+
+  run "$SCRIPT" -s 2.0 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+
+  run "$SCRIPT" --speed-factor 2.0 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+
+  run "$SCRIPT" -s 2 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+
+  run "$SCRIPT" --speed-factor 2 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+
+  run "$SCRIPT" -s 1,5 --no-process "$TMPDIR_TEST"
+  [ "$status" -eq 0 ]
+
   run "$SCRIPT" --speed-factor 1,5 --no-process "$TMPDIR_TEST"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
### Motivation

- Reduce duplication and make tests cover both short and long option forms consistently for `-v/--version` and `-h/--help`.
- Validate `--speed-factor` parsing more thoroughly, including numeric validation, allowed range, and format edge cases.
- Ensure successful speed-factor values are exercised in `--no-process` mode to avoid invoking external processing during unit tests.

### Description

- Consolidated separate tests for version and help into combined tests that assert both short and long options (`-v/--version`, `-h/--help`).
- Combined and renamed many speed-factor tests to check both `-s` and `--speed-factor` variants in single test cases.
- Added validation tests for non-numeric values, values below `0.5`, values above `2.0`, and the leading-digit requirement (rejecting `.5`).
- Added grouped success tests that run multiple valid `--speed-factor` values (including `0.5`, `1.5`, `2.0`, `2`, and `1,5`) in `--no-process` mode and removed duplicated/overlapping cases.

### Testing

- Ran the updated test file with `bats test/fps_fixer.bats`, and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b7407014832b974a39d507bb90fa)

Issue: #12