### PR TITLE
Add FPS processing coverage tests

### DIFF
--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -222,140 +222,191 @@ ffmpeg_processing_call_count() {
 }
 
 @test "target fps comparison honors default epsilon boundaries" {
-  mkdir -p "$TMPDIR_TEST/in"
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r exact_fps_video="$input_dir/exact.mp4"
+  declare -r below_within_epsilon_video="$input_dir/below-within.mp4"
+  declare -r lower_epsilon_boundary_video="$input_dir/lower-boundary.mp4"
+  declare -r above_within_epsilon_video="$input_dir/above-within.mp4"
+  declare -r upper_epsilon_boundary_video="$input_dir/upper-boundary.mp4"
+  declare -r below_outside_epsilon_video="$input_dir/below-outside.mp4"
+  declare -r above_outside_epsilon_video="$input_dir/above-outside.mp4"
+  declare -r exact_fps_fixed_video="$input_dir/fixed-videos/exact.60_fps.mp4"
+  declare -r below_within_epsilon_fixed_video="$input_dir/fixed-videos/below-within.60_fps.mp4"
+  declare -r lower_epsilon_boundary_fixed_video="$input_dir/fixed-videos/lower-boundary.60_fps.mp4"
+  declare -r above_within_epsilon_fixed_video="$input_dir/fixed-videos/above-within.60_fps.mp4"
+  declare -r upper_epsilon_boundary_fixed_video="$input_dir/fixed-videos/upper-boundary.60_fps.mp4"
+  declare -r below_outside_epsilon_fixed_video="$input_dir/fixed-videos/below-outside.60_fps.mp4"
+  declare -r above_outside_epsilon_fixed_video="$input_dir/fixed-videos/above-outside.60_fps.mp4"
+
+  mkdir -p "$input_dir"
   touch \
-    "$TMPDIR_TEST/in/exact.mp4" \
-    "$TMPDIR_TEST/in/below-within.mp4" \
-    "$TMPDIR_TEST/in/lower-boundary.mp4" \
-    "$TMPDIR_TEST/in/above-within.mp4" \
-    "$TMPDIR_TEST/in/upper-boundary.mp4" \
-    "$TMPDIR_TEST/in/below-outside.mp4" \
-    "$TMPDIR_TEST/in/above-outside.mp4"
+    "$exact_fps_video" \
+    "$below_within_epsilon_video" \
+    "$lower_epsilon_boundary_video" \
+    "$above_within_epsilon_video" \
+    "$upper_epsilon_boundary_video" \
+    "$below_outside_epsilon_video" \
+    "$above_outside_epsilon_video"
   {
-    printf '%s|60\n' "$TMPDIR_TEST/in/exact.mp4"
-    printf '%s|59.5\n' "$TMPDIR_TEST/in/below-within.mp4"
-    printf '%s|58\n' "$TMPDIR_TEST/in/lower-boundary.mp4"
-    printf '%s|60.5\n' "$TMPDIR_TEST/in/above-within.mp4"
-    printf '%s|62\n' "$TMPDIR_TEST/in/upper-boundary.mp4"
-    printf '%s|57.99\n' "$TMPDIR_TEST/in/below-outside.mp4"
-    printf '%s|62.01\n' "$TMPDIR_TEST/in/above-outside.mp4"
+    printf '%s|60\n' "$exact_fps_video"
+    printf '%s|59.5\n' "$below_within_epsilon_video"
+    printf '%s|58\n' "$lower_epsilon_boundary_video"
+    printf '%s|60.5\n' "$above_within_epsilon_video"
+    printf '%s|62\n' "$upper_epsilon_boundary_video"
+    printf '%s|57.99\n' "$below_outside_epsilon_video"
+    printf '%s|62.01\n' "$above_outside_epsilon_video"
   } > "$FFMPEG_FPS_MAP_FILE"
 
-  run "$SCRIPT" "$TMPDIR_TEST/in"
+  run "$SCRIPT" "$input_dir"
   [ "$status" -eq 0 ]
-  [ ! -f "$TMPDIR_TEST/in/fixed-videos/exact.60_fps.mp4" ]
-  [ ! -f "$TMPDIR_TEST/in/fixed-videos/below-within.60_fps.mp4" ]
-  [ ! -f "$TMPDIR_TEST/in/fixed-videos/lower-boundary.60_fps.mp4" ]
-  [ ! -f "$TMPDIR_TEST/in/fixed-videos/above-within.60_fps.mp4" ]
-  [ ! -f "$TMPDIR_TEST/in/fixed-videos/upper-boundary.60_fps.mp4" ]
-  [ -f "$TMPDIR_TEST/in/fixed-videos/below-outside.60_fps.mp4" ]
-  [ -f "$TMPDIR_TEST/in/fixed-videos/above-outside.60_fps.mp4" ]
+  [ ! -f "$exact_fps_fixed_video" ]
+  [ ! -f "$below_within_epsilon_fixed_video" ]
+  [ ! -f "$lower_epsilon_boundary_fixed_video" ]
+  [ ! -f "$above_within_epsilon_fixed_video" ]
+  [ ! -f "$upper_epsilon_boundary_fixed_video" ]
+  [ -f "$below_outside_epsilon_fixed_video" ]
+  [ -f "$above_outside_epsilon_fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 2 ]
 }
 
 @test "processing command uses default FPS settings and maps streams" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/video.mp4"
-  printf '%s|50\n' "$TMPDIR_TEST/in/video.mp4" > "$FFMPEG_FPS_MAP_FILE"
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/video.mp4"
+  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
 
-  run "$SCRIPT" "$TMPDIR_TEST/in"
+  mkdir -p "$input_dir"
+  touch "$video"
+  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" "$input_dir"
   [ "$status" -eq 0 ]
-  [ -f "$TMPDIR_TEST/in/fixed-videos/video.60_fps.mp4" ]
+  [ -f "$fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 1 ]
   grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
   grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-  grep -F -- "$TMPDIR_TEST/in/fixed-videos/video.60_fps.mp4" "$FFMPEG_LOG_FILE"
+  grep -F -- "$fixed_video" "$FFMPEG_LOG_FILE"
 }
 
 @test "custom target FPS via short and long options is respected" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r target_fps_video="$input_dir/target.mp4"
+  declare -r non_target_fps_video="$input_dir/fix.mp4"
+  declare -r target_fps_fixed_video="$input_dir/fixed-videos/target.48_fps.mp4"
+  declare -r non_target_fps_fixed_video="$input_dir/fixed-videos/fix.48_fps.mp4"
+
   for fps_option in -f --fps; do
-    rm -rf "$TMPDIR_TEST/in"
+    rm -rf "$input_dir"
     : > "$FFMPEG_LOG_FILE"
-    mkdir -p "$TMPDIR_TEST/in"
-    touch "$TMPDIR_TEST/in/target.mp4" "$TMPDIR_TEST/in/fix.mp4"
+    mkdir -p "$input_dir"
+    touch "$target_fps_video" "$non_target_fps_video"
     {
-      printf '%s|48\n' "$TMPDIR_TEST/in/target.mp4"
-      printf '%s|45\n' "$TMPDIR_TEST/in/fix.mp4"
+      printf '%s|48\n' "$target_fps_video"
+      printf '%s|45\n' "$non_target_fps_video"
     } > "$FFMPEG_FPS_MAP_FILE"
 
-    run "$SCRIPT" "$fps_option" 48 "$TMPDIR_TEST/in"
+    run "$SCRIPT" "$fps_option" 48 "$input_dir"
     [ "$status" -eq 0 ]
-    [ ! -f "$TMPDIR_TEST/in/fixed-videos/target.48_fps.mp4" ]
-    [ -f "$TMPDIR_TEST/in/fixed-videos/fix.48_fps.mp4" ]
+    [ ! -f "$target_fps_fixed_video" ]
+    [ -f "$non_target_fps_fixed_video" ]
     [ "$(ffmpeg_processing_call_count)" -eq 1 ]
     grep -F -- "-filter:v fps=48" "$FFMPEG_LOG_FILE"
-    grep -F -- "$TMPDIR_TEST/in/fixed-videos/fix.48_fps.mp4" "$FFMPEG_LOG_FILE"
+    grep -F -- "$non_target_fps_fixed_video" "$FFMPEG_LOG_FILE"
   done
 }
 
 @test "custom epsilon via short and long options is respected" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r within_epsilon_video="$input_dir/within.mp4"
+  declare -r outside_epsilon_video="$input_dir/outside.mp4"
+  declare -r within_epsilon_fixed_video="$input_dir/fixed-videos/within.60_fps.mp4"
+  declare -r outside_epsilon_fixed_video="$input_dir/fixed-videos/outside.60_fps.mp4"
+
   for epsilon_option in -E --epsilon; do
-    rm -rf "$TMPDIR_TEST/in"
+    rm -rf "$input_dir"
     : > "$FFMPEG_LOG_FILE"
-    mkdir -p "$TMPDIR_TEST/in"
-    touch "$TMPDIR_TEST/in/within.mp4" "$TMPDIR_TEST/in/outside.mp4"
+    mkdir -p "$input_dir"
+    touch "$within_epsilon_video" "$outside_epsilon_video"
     {
-      printf '%s|59.5\n' "$TMPDIR_TEST/in/within.mp4"
-      printf '%s|59.49\n' "$TMPDIR_TEST/in/outside.mp4"
+      printf '%s|59.5\n' "$within_epsilon_video"
+      printf '%s|59.49\n' "$outside_epsilon_video"
     } > "$FFMPEG_FPS_MAP_FILE"
 
-    run "$SCRIPT" "$epsilon_option" 0.5 "$TMPDIR_TEST/in"
+    run "$SCRIPT" "$epsilon_option" 0.5 "$input_dir"
     [ "$status" -eq 0 ]
-    [ ! -f "$TMPDIR_TEST/in/fixed-videos/within.60_fps.mp4" ]
-    [ -f "$TMPDIR_TEST/in/fixed-videos/outside.60_fps.mp4" ]
+    [ ! -f "$within_epsilon_fixed_video" ]
+    [ -f "$outside_epsilon_fixed_video" ]
     [ "$(ffmpeg_processing_call_count)" -eq 1 ]
   done
 }
 
 @test "fractional FPS with dot and comma notation is handled" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/dot.mp4" "$TMPDIR_TEST/in/comma.mp4" "$TMPDIR_TEST/in/fix.mp4"
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r dot_fps_video="$input_dir/dot.mp4"
+  declare -r comma_fps_video="$input_dir/comma.mp4"
+  declare -r non_target_fps_video="$input_dir/fix.mp4"
+  declare -r dot_fps_fixed_video="$input_dir/fixed-videos/dot.59.94_fps.mp4"
+  declare -r comma_fps_fixed_video="$input_dir/fixed-videos/comma.59.94_fps.mp4"
+  declare -r non_target_fps_fixed_video="$input_dir/fixed-videos/fix.59.94_fps.mp4"
+
+  mkdir -p "$input_dir"
+  touch "$dot_fps_video" "$comma_fps_video" "$non_target_fps_video"
   {
-    printf '%s|59.94\n' "$TMPDIR_TEST/in/dot.mp4"
-    printf '%s|59,94\n' "$TMPDIR_TEST/in/comma.mp4"
-    printf '%s|58\n' "$TMPDIR_TEST/in/fix.mp4"
+    printf '%s|59.94\n' "$dot_fps_video"
+    printf '%s|59,94\n' "$comma_fps_video"
+    printf '%s|58\n' "$non_target_fps_video"
   } > "$FFMPEG_FPS_MAP_FILE"
 
-  run "$SCRIPT" --fps 59.94 --epsilon 0 "$TMPDIR_TEST/in"
+  run "$SCRIPT" --fps 59.94 --epsilon 0 "$input_dir"
   [ "$status" -eq 0 ]
-  [ ! -f "$TMPDIR_TEST/in/fixed-videos/dot.59.94_fps.mp4" ]
-  [ ! -f "$TMPDIR_TEST/in/fixed-videos/comma.59.94_fps.mp4" ]
-  [ -f "$TMPDIR_TEST/in/fixed-videos/fix.59.94_fps.mp4" ]
+  [ ! -f "$dot_fps_fixed_video" ]
+  [ ! -f "$comma_fps_fixed_video" ]
+  [ -f "$non_target_fps_fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 1 ]
   grep -F -- "-filter:v fps=59.94" "$FFMPEG_LOG_FILE"
 }
 
 @test "only the first FPS match from ffmpeg output is used" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/first-target.mp4"
-  printf '%s|60 fps, 50\n' "$TMPDIR_TEST/in/first-target.mp4" > "$FFMPEG_FPS_MAP_FILE"
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r first_target_fps_video="$input_dir/first-target.mp4"
+  declare -r first_target_fps_fixed_video="$input_dir/fixed-videos/first-target.60_fps.mp4"
 
-  run "$SCRIPT" "$TMPDIR_TEST/in"
+  mkdir -p "$input_dir"
+  touch "$first_target_fps_video"
+  printf '%s|60 fps, 50\n' "$first_target_fps_video" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" "$input_dir"
   [ "$status" -eq 0 ]
-  [ ! -f "$TMPDIR_TEST/in/fixed-videos/first-target.60_fps.mp4" ]
+  [ ! -f "$first_target_fps_fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 0 ]
 }
 
 @test "selected extension and base path are used for output path" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/video.mov"
-  printf '%s|50\n' "$TMPDIR_TEST/in/video.mov" > "$FFMPEG_FPS_MAP_FILE"
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/video.mov"
+  declare -r fixed_video="$input_dir/out/video.60_fps.mov"
 
-  run "$SCRIPT" --extension mov --base-path out "$TMPDIR_TEST/in"
+  mkdir -p "$input_dir"
+  touch "$video"
+  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --extension mov --base-path out "$input_dir"
   [ "$status" -eq 0 ]
-  [ -f "$TMPDIR_TEST/in/out/video.60_fps.mov" ]
+  [ -f "$fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 1 ]
-  grep -F -- "$TMPDIR_TEST/in/out/video.60_fps.mov" "$FFMPEG_LOG_FILE"
+  grep -F -- "$fixed_video" "$FFMPEG_LOG_FILE"
 }
 
 @test "--no-audio uses -an and skips optional audio map in processing command" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/a.mp4"
-  printf '%s|50\n' "$TMPDIR_TEST/in/a.mp4" > "$FFMPEG_FPS_MAP_FILE"
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/a.mp4"
 
-  run "$SCRIPT" --no-audio "$TMPDIR_TEST/in"
+  mkdir -p "$input_dir"
+  touch "$video"
+  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --no-audio "$input_dir"
   [ "$status" -eq 0 ]
   [ "$(ffmpeg_processing_call_count)" -eq 1 ]
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -272,6 +272,12 @@ ffmpeg_processing_call_count() {
   [ -f "$below_outside_epsilon_fixed_video" ]
   [ -f "$above_outside_epsilon_fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 2 ]
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+  grep -F -- "$below_outside_epsilon_fixed_video" "$FFMPEG_LOG_FILE"
+  grep -F -- "$above_outside_epsilon_fixed_video" "$FFMPEG_LOG_FILE"
 }
 
 @test "processing command uses default FPS settings and maps streams" {
@@ -322,6 +328,9 @@ ffmpeg_processing_call_count() {
     [ -f "$non_target_fps_fixed_video" ]
     [ "$(ffmpeg_processing_call_count)" -eq 1 ]
     grep -F -- "-filter:v fps=48" "$FFMPEG_LOG_FILE"
+    grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
+    grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+    grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
     grep -F -- "$non_target_fps_fixed_video" "$FFMPEG_LOG_FILE"
   done
 }
@@ -351,6 +360,11 @@ ffmpeg_processing_call_count() {
     [ ! -f "$within_epsilon_fixed_video" ]
     [ -f "$outside_epsilon_fixed_video" ]
     [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+    grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+    grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
+    grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+    grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+    grep -F -- "$outside_epsilon_fixed_video" "$FFMPEG_LOG_FILE"
   done
 }
 
@@ -380,6 +394,10 @@ ffmpeg_processing_call_count() {
   [ -f "$non_target_fps_fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 1 ]
   grep -F -- "-filter:v fps=59.94" "$FFMPEG_LOG_FILE"
+  grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+  grep -F -- "$non_target_fps_fixed_video" "$FFMPEG_LOG_FILE"
 }
 
 @test "only the first FPS match from ffmpeg output is used" {
@@ -414,6 +432,10 @@ ffmpeg_processing_call_count() {
   [ "$status" -eq 0 ]
   [ -f "$fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
   grep -F -- "$fixed_video" "$FFMPEG_LOG_FILE"
 }
 
@@ -429,7 +451,10 @@ ffmpeg_processing_call_count() {
 
 @test "--no-audio uses -an and skips optional audio map in processing command" {
   declare -r input_dir="$TMPDIR_TEST/in"
-  declare -r video="$input_dir/a.mp4"
+  declare -r video="$input_dir/video.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
 
   mkdir -p "$input_dir"
   touch "$video"
@@ -437,10 +462,14 @@ ffmpeg_processing_call_count() {
 
   run "$SCRIPT" --no-audio "$input_dir"
   [ "$status" -eq 0 ]
+  [ -f "$fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
-  grep -F -- "-an" "$FFMPEG_LOG_FILE"
   ! grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+  grep -F -- "-an" "$FFMPEG_LOG_FILE"
+  grep -F -- "$fixed_video" "$FFMPEG_LOG_FILE"
 }
 
 @test "--speed-factor generates acceleration output" {

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -398,6 +398,16 @@ ffmpeg_processing_call_count() {
   grep -F -- "$fixed_video" "$FFMPEG_LOG_FILE"
 }
 
+@test "--force skips probe and processes all" {
+  mkdir -p "$TMPDIR_TEST/in"
+  touch "$TMPDIR_TEST/in/a.mp4"
+
+  run "$SCRIPT" --force "$TMPDIR_TEST/in"
+  [ "$status" -eq 0 ]
+  ! grep -x -- "-i $TMPDIR_TEST/in/a.mp4" "$FFMPEG_LOG_FILE"
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+}
+
 @test "--no-audio uses -an and skips optional audio map in processing command" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/a.mp4"
@@ -413,17 +423,6 @@ ffmpeg_processing_call_count() {
   grep -F -- "-an" "$FFMPEG_LOG_FILE"
   ! grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
 }
-
-@test "--force skips probe and processes all" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/a.mp4"
-
-  run "$SCRIPT" --force "$TMPDIR_TEST/in"
-  [ "$status" -eq 0 ]
-  ! grep -x -- "-i $TMPDIR_TEST/in/a.mp4" "$FFMPEG_LOG_FILE"
-  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
-}
-
 
 @test "--speed-factor generates acceleration output" {
   mkdir -p "$TMPDIR_TEST/in"

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -210,20 +210,6 @@ ffmpeg_processing_call_count() {
   [ ! -d "$TMPDIR_TEST/in/fixed-videos" ]
 }
 
-@test "target fps is skipped; non-target is processed" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/ok.mp4" "$TMPDIR_TEST/in/fix.mp4"
-  {
-    printf '%s|60\n' "$TMPDIR_TEST/in/ok.mp4"
-    printf '%s|50\n' "$TMPDIR_TEST/in/fix.mp4"
-  } > "$FFMPEG_FPS_MAP_FILE"
-
-  run "$SCRIPT" "$TMPDIR_TEST/in"
-  [ "$status" -eq 0 ]
-  [ -f "$TMPDIR_TEST/in/fixed-videos/fix.60_fps.mp4" ]
-  [ ! -f "$TMPDIR_TEST/in/fixed-videos/ok.60_fps.mp4" ]
-}
-
 @test "target FPS comparison honors default epsilon boundaries" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r exact_fps_video="$input_dir/exact.mp4"
@@ -278,28 +264,6 @@ ffmpeg_processing_call_count() {
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
   grep -F -- "$below_outside_epsilon_fixed_video" "$FFMPEG_LOG_FILE"
   grep -F -- "$above_outside_epsilon_fixed_video" "$FFMPEG_LOG_FILE"
-}
-
-@test "processing command uses default FPS settings and maps streams" {
-  declare -r input_dir="$TMPDIR_TEST/in"
-  declare -r video="$input_dir/video.mp4"
-
-  declare -r fixed_videos_dir="$input_dir/fixed-videos"
-  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
-
-  mkdir -p "$input_dir"
-  touch "$video"
-  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
-
-  run "$SCRIPT" "$input_dir"
-  [ "$status" -eq 0 ]
-  [ -f "$fixed_video" ]
-  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
-  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
-  grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
-  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
-  grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-  grep -F -- "$fixed_video" "$FFMPEG_LOG_FILE"
 }
 
 @test "custom target FPS via -f and --fps is respected" {

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -15,6 +15,14 @@ teardown() {
   rm -rf "$TMPDIR_TEST"
 }
 
+ffmpeg_processing_calls() {
+  grep -F -- "-filter:v fps=" "$FFMPEG_LOG_FILE" || true
+}
+
+ffmpeg_processing_call_count() {
+  ffmpeg_processing_calls | wc -l | tr -d ' '
+}
+
 @test "-v and --version exit 0" {
   run "$SCRIPT" -v
   [ "$status" -eq 0 ]
@@ -213,6 +221,148 @@ teardown() {
   [ ! -f "$TMPDIR_TEST/in/fixed-videos/ok.60_fps.mp4" ]
 }
 
+@test "target fps comparison honors default epsilon boundaries" {
+  mkdir -p "$TMPDIR_TEST/in"
+  touch \
+    "$TMPDIR_TEST/in/exact.mp4" \
+    "$TMPDIR_TEST/in/below-within.mp4" \
+    "$TMPDIR_TEST/in/lower-boundary.mp4" \
+    "$TMPDIR_TEST/in/above-within.mp4" \
+    "$TMPDIR_TEST/in/upper-boundary.mp4" \
+    "$TMPDIR_TEST/in/below-outside.mp4" \
+    "$TMPDIR_TEST/in/above-outside.mp4"
+  {
+    printf '%s|60\n' "$TMPDIR_TEST/in/exact.mp4"
+    printf '%s|59.5\n' "$TMPDIR_TEST/in/below-within.mp4"
+    printf '%s|58\n' "$TMPDIR_TEST/in/lower-boundary.mp4"
+    printf '%s|60.5\n' "$TMPDIR_TEST/in/above-within.mp4"
+    printf '%s|62\n' "$TMPDIR_TEST/in/upper-boundary.mp4"
+    printf '%s|57.99\n' "$TMPDIR_TEST/in/below-outside.mp4"
+    printf '%s|62.01\n' "$TMPDIR_TEST/in/above-outside.mp4"
+  } > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" "$TMPDIR_TEST/in"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TMPDIR_TEST/in/fixed-videos/exact.60_fps.mp4" ]
+  [ ! -f "$TMPDIR_TEST/in/fixed-videos/below-within.60_fps.mp4" ]
+  [ ! -f "$TMPDIR_TEST/in/fixed-videos/lower-boundary.60_fps.mp4" ]
+  [ ! -f "$TMPDIR_TEST/in/fixed-videos/above-within.60_fps.mp4" ]
+  [ ! -f "$TMPDIR_TEST/in/fixed-videos/upper-boundary.60_fps.mp4" ]
+  [ -f "$TMPDIR_TEST/in/fixed-videos/below-outside.60_fps.mp4" ]
+  [ -f "$TMPDIR_TEST/in/fixed-videos/above-outside.60_fps.mp4" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 2 ]
+}
+
+@test "processing command uses default FPS settings and maps streams" {
+  mkdir -p "$TMPDIR_TEST/in"
+  touch "$TMPDIR_TEST/in/video.mp4"
+  printf '%s|50\n' "$TMPDIR_TEST/in/video.mp4" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" "$TMPDIR_TEST/in"
+  [ "$status" -eq 0 ]
+  [ -f "$TMPDIR_TEST/in/fixed-videos/video.60_fps.mp4" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+  grep -F -- "$TMPDIR_TEST/in/fixed-videos/video.60_fps.mp4" "$FFMPEG_LOG_FILE"
+}
+
+@test "custom target FPS via short and long options is respected" {
+  for fps_option in -f --fps; do
+    rm -rf "$TMPDIR_TEST/in"
+    : > "$FFMPEG_LOG_FILE"
+    mkdir -p "$TMPDIR_TEST/in"
+    touch "$TMPDIR_TEST/in/target.mp4" "$TMPDIR_TEST/in/fix.mp4"
+    {
+      printf '%s|48\n' "$TMPDIR_TEST/in/target.mp4"
+      printf '%s|45\n' "$TMPDIR_TEST/in/fix.mp4"
+    } > "$FFMPEG_FPS_MAP_FILE"
+
+    run "$SCRIPT" "$fps_option" 48 "$TMPDIR_TEST/in"
+    [ "$status" -eq 0 ]
+    [ ! -f "$TMPDIR_TEST/in/fixed-videos/target.48_fps.mp4" ]
+    [ -f "$TMPDIR_TEST/in/fixed-videos/fix.48_fps.mp4" ]
+    [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+    grep -F -- "-filter:v fps=48" "$FFMPEG_LOG_FILE"
+    grep -F -- "$TMPDIR_TEST/in/fixed-videos/fix.48_fps.mp4" "$FFMPEG_LOG_FILE"
+  done
+}
+
+@test "custom epsilon via short and long options is respected" {
+  for epsilon_option in -E --epsilon; do
+    rm -rf "$TMPDIR_TEST/in"
+    : > "$FFMPEG_LOG_FILE"
+    mkdir -p "$TMPDIR_TEST/in"
+    touch "$TMPDIR_TEST/in/within.mp4" "$TMPDIR_TEST/in/outside.mp4"
+    {
+      printf '%s|59.5\n' "$TMPDIR_TEST/in/within.mp4"
+      printf '%s|59.49\n' "$TMPDIR_TEST/in/outside.mp4"
+    } > "$FFMPEG_FPS_MAP_FILE"
+
+    run "$SCRIPT" "$epsilon_option" 0.5 "$TMPDIR_TEST/in"
+    [ "$status" -eq 0 ]
+    [ ! -f "$TMPDIR_TEST/in/fixed-videos/within.60_fps.mp4" ]
+    [ -f "$TMPDIR_TEST/in/fixed-videos/outside.60_fps.mp4" ]
+    [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  done
+}
+
+@test "fractional FPS with dot and comma notation is handled" {
+  mkdir -p "$TMPDIR_TEST/in"
+  touch "$TMPDIR_TEST/in/dot.mp4" "$TMPDIR_TEST/in/comma.mp4" "$TMPDIR_TEST/in/fix.mp4"
+  {
+    printf '%s|59.94\n' "$TMPDIR_TEST/in/dot.mp4"
+    printf '%s|59,94\n' "$TMPDIR_TEST/in/comma.mp4"
+    printf '%s|58\n' "$TMPDIR_TEST/in/fix.mp4"
+  } > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --fps 59.94 --epsilon 0 "$TMPDIR_TEST/in"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TMPDIR_TEST/in/fixed-videos/dot.59.94_fps.mp4" ]
+  [ ! -f "$TMPDIR_TEST/in/fixed-videos/comma.59.94_fps.mp4" ]
+  [ -f "$TMPDIR_TEST/in/fixed-videos/fix.59.94_fps.mp4" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "-filter:v fps=59.94" "$FFMPEG_LOG_FILE"
+}
+
+@test "only the first FPS match from ffmpeg output is used" {
+  mkdir -p "$TMPDIR_TEST/in"
+  touch "$TMPDIR_TEST/in/first-target.mp4"
+  printf '%s|60 fps, 50\n' "$TMPDIR_TEST/in/first-target.mp4" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" "$TMPDIR_TEST/in"
+  [ "$status" -eq 0 ]
+  [ ! -f "$TMPDIR_TEST/in/fixed-videos/first-target.60_fps.mp4" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 0 ]
+}
+
+@test "selected extension and base path are used for output path" {
+  mkdir -p "$TMPDIR_TEST/in"
+  touch "$TMPDIR_TEST/in/video.mov"
+  printf '%s|50\n' "$TMPDIR_TEST/in/video.mov" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --extension mov --base-path out "$TMPDIR_TEST/in"
+  [ "$status" -eq 0 ]
+  [ -f "$TMPDIR_TEST/in/out/video.60_fps.mov" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "$TMPDIR_TEST/in/out/video.60_fps.mov" "$FFMPEG_LOG_FILE"
+}
+
+@test "--no-audio uses -an and skips optional audio map in processing command" {
+  mkdir -p "$TMPDIR_TEST/in"
+  touch "$TMPDIR_TEST/in/a.mp4"
+  printf '%s|50\n' "$TMPDIR_TEST/in/a.mp4" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --no-audio "$TMPDIR_TEST/in"
+  [ "$status" -eq 0 ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+  grep -F -- "-an" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+}
+
 @test "--force skips probe and processes all" {
   mkdir -p "$TMPDIR_TEST/in"
   touch "$TMPDIR_TEST/in/a.mp4"
@@ -223,16 +373,6 @@ teardown() {
   grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
 }
 
-@test "--no-audio uses -an and no audio map" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/a.mp4"
-  printf '%s|50\n' "$TMPDIR_TEST/in/a.mp4" > "$FFMPEG_FPS_MAP_FILE"
-
-  run "$SCRIPT" --no-audio "$TMPDIR_TEST/in"
-  [ "$status" -eq 0 ]
-  grep -F -- "-an" "$FFMPEG_LOG_FILE"
-  ! grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-}
 
 @test "--speed-factor generates acceleration output" {
   mkdir -p "$TMPDIR_TEST/in"

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -118,20 +118,21 @@ ffmpeg_processing_call_count() {
 }
 
 @test "default discovery only mp4 files and no nested" {
-  declare -r top_level_mp4="$TMPDIR_TEST/in/a.mp4"
-  declare -r top_level_mp4_with_spaces="$TMPDIR_TEST/in/my video.mp4"
-  declare -r top_level_mp4_with_parentheses="$TMPDIR_TEST/in/video (1).mp4"
-  declare -r top_level_mp4_with_apostrophe="$TMPDIR_TEST/in/john's video.mp4"
-  declare -r top_level_mp4_cyrillic="$TMPDIR_TEST/in/видео.mp4"
-  declare -r top_level_mp4_many_dots="$TMPDIR_TEST/in/my.video.test.mp4"
-  declare -r top_level_non_target_mov="$TMPDIR_TEST/in/b.mov"
-  declare -r fake_mp4_directory="$TMPDIR_TEST/in/fake.mp4"
-  declare -r top_level_mp4_uppercase_extension="$TMPDIR_TEST/in/video.MP4"
-  declare -r top_level_no_extension="$TMPDIR_TEST/in/video"
-  declare -r top_level_backup_file="$TMPDIR_TEST/in/video.mp4.backup"
-  declare -r nested_mp4="$TMPDIR_TEST/in/sub/c.mp4"
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r top_level_mp4="$input_dir/a.mp4"
+  declare -r top_level_mp4_with_spaces="$input_dir/my video.mp4"
+  declare -r top_level_mp4_with_parentheses="$input_dir/video (1).mp4"
+  declare -r top_level_mp4_with_apostrophe="$input_dir/john's video.mp4"
+  declare -r top_level_mp4_cyrillic="$input_dir/видео.mp4"
+  declare -r top_level_mp4_many_dots="$input_dir/my.video.test.mp4"
+  declare -r top_level_non_target_mov="$input_dir/b.mov"
+  declare -r fake_mp4_directory="$input_dir/fake.mp4"
+  declare -r top_level_mp4_uppercase_extension="$input_dir/video.MP4"
+  declare -r top_level_no_extension="$input_dir/video"
+  declare -r top_level_backup_file="$input_dir/video.mp4.backup"
+  declare -r nested_mp4="$input_dir/sub/c.mp4"
 
-  mkdir -p "$fake_mp4_directory" "$TMPDIR_TEST/in/sub"
+  mkdir -p "$fake_mp4_directory" "$input_dir/sub"
   touch \
     "$top_level_mp4" \
     "$top_level_mp4_with_spaces" \
@@ -153,7 +154,7 @@ ffmpeg_processing_call_count() {
     printf '%s|50\n' "$top_level_mp4_many_dots"
   } > "$FFMPEG_FPS_MAP_FILE"
 
-  run "$SCRIPT" --no-process "$TMPDIR_TEST/in"
+  run "$SCRIPT" --no-process "$input_dir"
   [ "$status" -eq 0 ]
   grep -F -- "-i $top_level_mp4" "$FFMPEG_LOG_FILE"
   grep -F -- "-i $top_level_mp4_with_spaces" "$FFMPEG_LOG_FILE"
@@ -170,28 +171,30 @@ ffmpeg_processing_call_count() {
 }
 
 @test "discovery mov with -e" {
-  declare -r top_level_non_target_mp4="$TMPDIR_TEST/in/a.mp4"
-  declare -r top_level_target_mov="$TMPDIR_TEST/in/b.mov"
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r top_level_non_target_mp4="$input_dir/a.mp4"
+  declare -r top_level_target_mov="$input_dir/b.mov"
 
-  mkdir -p "$TMPDIR_TEST/in"
+  mkdir -p "$input_dir"
   touch "$top_level_non_target_mp4" "$top_level_target_mov"
   printf '%s|50\n' "$top_level_target_mov" > "$FFMPEG_FPS_MAP_FILE"
 
-  run "$SCRIPT" -e "mov" --no-process "$TMPDIR_TEST/in"
+  run "$SCRIPT" -e "mov" --no-process "$input_dir"
   [ "$status" -eq 0 ]
   ! grep -F -- "-i $top_level_non_target_mp4" "$FFMPEG_LOG_FILE"
   grep -F -- "-i $top_level_target_mov" "$FFMPEG_LOG_FILE"
 }
 
 @test "discovery mov with --extension" {
-  declare -r top_level_non_target_mp4="$TMPDIR_TEST/in/a.mp4"
-  declare -r top_level_target_mov="$TMPDIR_TEST/in/b.mov"
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r top_level_non_target_mp4="$input_dir/a.mp4"
+  declare -r top_level_target_mov="$input_dir/b.mov"
 
-  mkdir -p "$TMPDIR_TEST/in"
+  mkdir -p "$input_dir"
   touch "$top_level_non_target_mp4" "$top_level_target_mov"
   printf '%s|50\n' "$top_level_target_mov" > "$FFMPEG_FPS_MAP_FILE"
 
-  run "$SCRIPT" --extension "mov" --no-process "$TMPDIR_TEST/in"
+  run "$SCRIPT" --extension "mov" --no-process "$input_dir"
   [ "$status" -eq 0 ]
   ! grep -F -- "-i $top_level_non_target_mp4" "$FFMPEG_LOG_FILE"
   grep -F -- "-i $top_level_target_mov" "$FFMPEG_LOG_FILE"
@@ -221,7 +224,7 @@ ffmpeg_processing_call_count() {
   [ ! -f "$TMPDIR_TEST/in/fixed-videos/ok.60_fps.mp4" ]
 }
 
-@test "target fps comparison honors default epsilon boundaries" {
+@test "target FPS comparison honors default epsilon boundaries" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r exact_fps_video="$input_dir/exact.mp4"
   declare -r below_within_epsilon_video="$input_dir/below-within.mp4"
@@ -230,13 +233,15 @@ ffmpeg_processing_call_count() {
   declare -r upper_epsilon_boundary_video="$input_dir/upper-boundary.mp4"
   declare -r below_outside_epsilon_video="$input_dir/below-outside.mp4"
   declare -r above_outside_epsilon_video="$input_dir/above-outside.mp4"
-  declare -r exact_fps_fixed_video="$input_dir/fixed-videos/exact.60_fps.mp4"
-  declare -r below_within_epsilon_fixed_video="$input_dir/fixed-videos/below-within.60_fps.mp4"
-  declare -r lower_epsilon_boundary_fixed_video="$input_dir/fixed-videos/lower-boundary.60_fps.mp4"
-  declare -r above_within_epsilon_fixed_video="$input_dir/fixed-videos/above-within.60_fps.mp4"
-  declare -r upper_epsilon_boundary_fixed_video="$input_dir/fixed-videos/upper-boundary.60_fps.mp4"
-  declare -r below_outside_epsilon_fixed_video="$input_dir/fixed-videos/below-outside.60_fps.mp4"
-  declare -r above_outside_epsilon_fixed_video="$input_dir/fixed-videos/above-outside.60_fps.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r exact_fps_fixed_video="$fixed_videos_dir/exact.60_fps.mp4"
+  declare -r below_within_epsilon_fixed_video="$fixed_videos_dir/below-within.60_fps.mp4"
+  declare -r lower_epsilon_boundary_fixed_video="$fixed_videos_dir/lower-boundary.60_fps.mp4"
+  declare -r above_within_epsilon_fixed_video="$fixed_videos_dir/above-within.60_fps.mp4"
+  declare -r upper_epsilon_boundary_fixed_video="$fixed_videos_dir/upper-boundary.60_fps.mp4"
+  declare -r below_outside_epsilon_fixed_video="$fixed_videos_dir/below-outside.60_fps.mp4"
+  declare -r above_outside_epsilon_fixed_video="$fixed_videos_dir/above-outside.60_fps.mp4"
 
   mkdir -p "$input_dir"
   touch \
@@ -272,7 +277,9 @@ ffmpeg_processing_call_count() {
 @test "processing command uses default FPS settings and maps streams" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/video.mp4"
-  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
 
   mkdir -p "$input_dir"
   touch "$video"
@@ -289,16 +296,19 @@ ffmpeg_processing_call_count() {
   grep -F -- "$fixed_video" "$FFMPEG_LOG_FILE"
 }
 
-@test "custom target FPS via short and long options is respected" {
+@test "custom target FPS via -f and --fps is respected" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r target_fps_video="$input_dir/target.mp4"
   declare -r non_target_fps_video="$input_dir/fix.mp4"
-  declare -r target_fps_fixed_video="$input_dir/fixed-videos/target.48_fps.mp4"
-  declare -r non_target_fps_fixed_video="$input_dir/fixed-videos/fix.48_fps.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r target_fps_fixed_video="$fixed_videos_dir/target.48_fps.mp4"
+  declare -r non_target_fps_fixed_video="$fixed_videos_dir/fix.48_fps.mp4"
 
   for fps_option in -f --fps; do
     rm -rf "$input_dir"
-    : > "$FFMPEG_LOG_FILE"
+    truncate -s 0 "$FFMPEG_LOG_FILE"
+
     mkdir -p "$input_dir"
     touch "$target_fps_video" "$non_target_fps_video"
     {
@@ -316,16 +326,19 @@ ffmpeg_processing_call_count() {
   done
 }
 
-@test "custom epsilon via short and long options is respected" {
+@test "custom epsilon via -E and --epsilon is respected" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r within_epsilon_video="$input_dir/within.mp4"
   declare -r outside_epsilon_video="$input_dir/outside.mp4"
-  declare -r within_epsilon_fixed_video="$input_dir/fixed-videos/within.60_fps.mp4"
-  declare -r outside_epsilon_fixed_video="$input_dir/fixed-videos/outside.60_fps.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r within_epsilon_fixed_video="$fixed_videos_dir/within.60_fps.mp4"
+  declare -r outside_epsilon_fixed_video="$fixed_videos_dir/outside.60_fps.mp4"
 
   for epsilon_option in -E --epsilon; do
     rm -rf "$input_dir"
-    : > "$FFMPEG_LOG_FILE"
+    truncate -s 0 "$FFMPEG_LOG_FILE"
+
     mkdir -p "$input_dir"
     touch "$within_epsilon_video" "$outside_epsilon_video"
     {
@@ -346,9 +359,11 @@ ffmpeg_processing_call_count() {
   declare -r dot_fps_video="$input_dir/dot.mp4"
   declare -r comma_fps_video="$input_dir/comma.mp4"
   declare -r non_target_fps_video="$input_dir/fix.mp4"
-  declare -r dot_fps_fixed_video="$input_dir/fixed-videos/dot.59.94_fps.mp4"
-  declare -r comma_fps_fixed_video="$input_dir/fixed-videos/comma.59.94_fps.mp4"
-  declare -r non_target_fps_fixed_video="$input_dir/fixed-videos/fix.59.94_fps.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r dot_fps_fixed_video="$fixed_videos_dir/dot.59.94_fps.mp4"
+  declare -r comma_fps_fixed_video="$fixed_videos_dir/comma.59.94_fps.mp4"
+  declare -r non_target_fps_fixed_video="$fixed_videos_dir/fix.59.94_fps.mp4"
 
   mkdir -p "$input_dir"
   touch "$dot_fps_video" "$comma_fps_video" "$non_target_fps_video"
@@ -370,7 +385,9 @@ ffmpeg_processing_call_count() {
 @test "only the first FPS match from ffmpeg output is used" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r first_target_fps_video="$input_dir/first-target.mp4"
-  declare -r first_target_fps_fixed_video="$input_dir/fixed-videos/first-target.60_fps.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r first_target_fps_fixed_video="$fixed_videos_dir/first-target.60_fps.mp4"
 
   mkdir -p "$input_dir"
   touch "$first_target_fps_video"
@@ -385,7 +402,9 @@ ffmpeg_processing_call_count() {
 @test "selected extension and base path are used for output path" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/video.mov"
-  declare -r fixed_video="$input_dir/out/video.60_fps.mov"
+
+  declare -r fixed_videos_dir="$input_dir/out"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mov"
 
   mkdir -p "$input_dir"
   touch "$video"

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -367,18 +367,29 @@ ffmpeg_processing_call_count() {
 @test "only the first FPS match from ffmpeg output is used" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r first_target_fps_video="$input_dir/first-target.mp4"
+  declare -r first_non_target_fps_video="$input_dir/first-non-target.mp4"
 
   declare -r fixed_videos_dir="$input_dir/fixed-videos"
   declare -r first_target_fps_fixed_video="$fixed_videos_dir/first-target.60_fps.mp4"
+  declare -r first_non_target_fps_fixed_video="$fixed_videos_dir/first-non-target.60_fps.mp4"
 
   mkdir -p "$input_dir"
-  touch "$first_target_fps_video"
-  printf '%s|60 fps, 50\n' "$first_target_fps_video" > "$FFMPEG_FPS_MAP_FILE"
+  touch "$first_target_fps_video" "$first_non_target_fps_video"
+  {
+    printf '%s|60 fps, 50\n' "$first_target_fps_video"
+    printf '%s|50 fps, 60\n' "$first_non_target_fps_video"
+  } > "$FFMPEG_FPS_MAP_FILE"
 
   run "$SCRIPT" "$input_dir"
   [ "$status" -eq 0 ]
   [ ! -f "$first_target_fps_fixed_video" ]
-  [ "$(ffmpeg_processing_call_count)" -eq 0 ]
+  [ -f "$first_non_target_fps_fixed_video" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+  grep -F -- "$first_non_target_fps_fixed_video" "$FFMPEG_LOG_FILE"
 }
 
 @test "selected extension and base path are used for output path" {


### PR DESCRIPTION
### Motivation
- Increase test coverage around FPS detection and the decision to skip or run ffmpeg processing, including edge cases for epsilon, fractional parsing and option overrides.

### Description
- Add helper functions `ffmpeg_processing_calls` and `ffmpeg_processing_call_count` to `test/fps_fixer.bats` to count real FPS-fixing ffmpeg invocations.
- Add tests that verify: exact target FPS, values within epsilon (including exact boundary values), values outside epsilon trigger processing, custom `-f|--fps` and `-E|--epsilon` handling, fractional FPS with dot and comma notations, and that only the first ffmpeg FPS match is used.
- Add assertions that processing command uses expected flags: `-filter:v fps=...`, `-fps_mode:v cfr`, `-map 0:v`, optional `-map 0:a?` or `-an`, output filename includes the `<target>_fps` suffix, selected extension and `--base-path` are respected, and the processing call count matches expectations.

### Testing
- Performed shell syntax checks with `bash -n fps_fixer.bash` and `bash -n test/bin/ffmpeg`, both succeeded.
- Could not run the test suite with `bats test/fps_fixer.bats` because `bats` is not installed in the environment, and attempting to install it via `apt-get` failed due to repository/proxy 403 errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1909373e88832b98e5a29e909851e2)

Issue: #12