### PR TITLE
Add tests for video acceleration options

### DIFF
--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -288,8 +288,7 @@ find "$original_video_base_path" -maxdepth 1 -type f -name "*.$video_extension" 
           -y \
           -i "$fixed_video_path" \
           -filter_complex "[0:v]setpts=PTS/$speed_factor[v]" \
-          -map "[v]" \
-          -an \
+          -map "[v]" -an \
           "$accelerated_video_path"
       fi
       log INFO "accelerated video path: $(ansi "$YELLOW" "$accelerated_video_path")"

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -31,7 +31,7 @@ load test_helper
   grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-  grep -F -- "$fixed_video" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
 @test "--force skips probe and processes all" {
@@ -64,7 +64,7 @@ load test_helper
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   ! grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
   grep -F -- "-an" "$FFMPEG_LOG_FILE"
-  grep -F -- "$fixed_video" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
 @test "--speed-factor generates acceleration output" {

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -34,29 +34,6 @@ load test_helper
   grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
-@test "--no-audio uses -an and skips optional audio map in processing command" {
-  declare -r input_dir="$TMPDIR_TEST/in"
-  declare -r video="$input_dir/video.mp4"
-
-  declare -r fixed_videos_dir="$input_dir/fixed-videos"
-  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
-
-  mkdir -p "$input_dir"
-  touch "$video"
-  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
-
-  run "$SCRIPT" --no-audio "$input_dir"
-  [ "$status" -eq 0 ]
-  [ -f "$fixed_video" ]
-  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
-  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
-  grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
-  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
-  ! grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-  grep -F -- "-an" "$FFMPEG_LOG_FILE"
-  grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
-}
-
 @test "probe failure warns and continues" {
   mkdir -p "$TMPDIR_TEST/in"
   touch "$TMPDIR_TEST/in/bad.mp4" "$TMPDIR_TEST/in/good.mp4"

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -67,17 +67,6 @@ load test_helper
   grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
-@test "--speed-factor generates acceleration output" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/a.mp4"
-  printf '%s|50\n' "$TMPDIR_TEST/in/a.mp4" > "$FFMPEG_FPS_MAP_FILE"
-
-  run "$SCRIPT" --speed-factor 1.5 "$TMPDIR_TEST/in"
-  [ "$status" -eq 0 ]
-  [ -f "$TMPDIR_TEST/in/fixed-videos/a.60_fps.1.5x.mp4" ]
-  grep -F -- "atempo=1.5" "$FFMPEG_LOG_FILE"
-}
-
 @test "probe failure warns and continues" {
   mkdir -p "$TMPDIR_TEST/in"
   touch "$TMPDIR_TEST/in/bad.mp4" "$TMPDIR_TEST/in/good.mp4"

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -34,16 +34,6 @@ load test_helper
   grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
-@test "--force skips probe and processes all" {
-  mkdir -p "$TMPDIR_TEST/in"
-  touch "$TMPDIR_TEST/in/a.mp4"
-
-  run "$SCRIPT" --force "$TMPDIR_TEST/in"
-  [ "$status" -eq 0 ]
-  ! grep -x -- "-i $TMPDIR_TEST/in/a.mp4" "$FFMPEG_LOG_FILE"
-  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
-}
-
 @test "--no-audio uses -an and skips optional audio map in processing command" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/video.mp4"

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -31,7 +31,7 @@ load test_helper
   grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-  grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_log_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
 @test "probe failure warns and continues" {

--- a/test/fps_processing.bats
+++ b/test/fps_processing.bats
@@ -54,8 +54,8 @@ load test_helper
   grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-  grep -F -- "$below_outside_epsilon_fixed_video" "$FFMPEG_LOG_FILE"
-  grep -F -- "$above_outside_epsilon_fixed_video" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_command_path "$below_outside_epsilon_fixed_video")" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_command_path "$above_outside_epsilon_fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
 @test "[$(test_file_group)] custom target FPS via -f and --fps is respected" {
@@ -87,7 +87,7 @@ load test_helper
     grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-    grep -F -- "$non_target_fps_fixed_video" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
   done
 }
 
@@ -121,7 +121,7 @@ load test_helper
       grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
       grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
       grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-      grep -F -- "$outside_epsilon_fixed_video" "$FFMPEG_LOG_FILE"
+      grep -F -- "$(ffmpeg_command_path "$outside_epsilon_fixed_video")" "$FFMPEG_LOG_FILE"
     done
   done
 }
@@ -159,7 +159,7 @@ load test_helper
     grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-    grep -F -- "$non_target_fps_fixed_video" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
   done
 }
 
@@ -188,5 +188,5 @@ load test_helper
   grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-  grep -F -- "$first_non_target_fps_fixed_video" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_command_path "$first_non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
 }

--- a/test/fps_processing.bats
+++ b/test/fps_processing.bats
@@ -218,3 +218,26 @@ load test_helper
     grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
   done
 }
+
+@test "[$(test_file_group)] --no-audio maps only video and disables audio" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/video.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
+
+  mkdir -p "$input_dir"
+  touch "$video"
+  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --no-audio "$input_dir"
+  [ "$status" -eq 0 ]
+  [ -f "$fixed_video" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+  grep -F -- "-an" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+}

--- a/test/fps_processing.bats
+++ b/test/fps_processing.bats
@@ -190,3 +190,31 @@ load test_helper
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
   grep -F -- "$(ffmpeg_command_path "$first_non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
 }
+
+@test "[$(test_file_group)] --force do not skip already target FPS videos" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/video.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
+
+  for force_option in -F --force; do
+    rm -rf "$input_dir"
+    truncate -s 0 "$FFMPEG_LOG_FILE"
+
+    mkdir -p "$input_dir"
+    touch "$video"
+    printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+    run "$SCRIPT" "$force_option" "$input_dir"
+    [ "$status" -eq 0 ]
+    [ -f "$fixed_video" ]
+    [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+    ! grep -x -- "-i $video" "$FFMPEG_LOG_FILE" # ensures the standalone probe command is absent
+    grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+    grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
+    grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+    grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+  done
+}

--- a/test/fps_processing.bats
+++ b/test/fps_processing.bats
@@ -54,8 +54,8 @@ load test_helper
   grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-  grep -F -- "$(ffmpeg_command_path "$below_outside_epsilon_fixed_video")" "$FFMPEG_LOG_FILE"
-  grep -F -- "$(ffmpeg_command_path "$above_outside_epsilon_fixed_video")" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_log_path "$below_outside_epsilon_fixed_video")" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_log_path "$above_outside_epsilon_fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
 @test "[$(test_file_group)] custom target FPS via -f and --fps is respected" {
@@ -87,7 +87,7 @@ load test_helper
     grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_log_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
   done
 }
 
@@ -121,7 +121,7 @@ load test_helper
       grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
       grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
       grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-      grep -F -- "$(ffmpeg_command_path "$outside_epsilon_fixed_video")" "$FFMPEG_LOG_FILE"
+      grep -F -- "$(ffmpeg_log_path "$outside_epsilon_fixed_video")" "$FFMPEG_LOG_FILE"
     done
   done
 }
@@ -159,7 +159,7 @@ load test_helper
     grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_log_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
   done
 }
 
@@ -188,7 +188,7 @@ load test_helper
   grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-  grep -F -- "$(ffmpeg_command_path "$first_non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_log_path "$first_non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
 @test "[$(test_file_group)] --force do not skip already target FPS videos" {
@@ -215,7 +215,7 @@ load test_helper
     grep -F -- "-fps_mode:v cfr" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
     grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_log_path "$fixed_video")" "$FFMPEG_LOG_FILE"
   done
 }
 
@@ -239,5 +239,5 @@ load test_helper
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   ! grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
   grep -F -- "-an" "$FFMPEG_LOG_FILE"
-  grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(ffmpeg_log_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -17,6 +17,10 @@ ffmpeg_processing_call_count() {
   grep -F -- "-filter:v fps=" "$FFMPEG_LOG_FILE" | wc -l | tr -d " "
 }
 
+ffmpeg_acceleration_call_count() {
+  grep -F -- "-filter_complex" "$FFMPEG_LOG_FILE" | wc -l | tr -d " "
+}
+
 test_file_group() {
   basename "$BATS_TEST_FILENAME" .bats
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -13,6 +13,10 @@ teardown() {
   rm -rf "$TMPDIR_TEST"
 }
 
+ffmpeg_command_path() {
+  printf './%s\n' "$(realpath --relative-to "." "$1")"
+}
+
 ffmpeg_processing_call_count() {
   grep -F -- "-filter:v fps=" "$FFMPEG_LOG_FILE" | wc -l | tr -d " "
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -13,6 +13,10 @@ teardown() {
   rm -rf "$TMPDIR_TEST"
 }
 
+test_file_group() {
+  basename "$BATS_TEST_FILENAME" .bats
+}
+
 ffmpeg_command_path() {
   printf './%s\n' "$(realpath --relative-to "." "$1")"
 }
@@ -25,6 +29,6 @@ ffmpeg_acceleration_call_count() {
   grep -F -- "-filter_complex" "$FFMPEG_LOG_FILE" | wc -l | tr -d " "
 }
 
-test_file_group() {
-  basename "$BATS_TEST_FILENAME" .bats
+ffmpeg_log_line_number() {
+  grep -nF -- "$1" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -17,8 +17,12 @@ test_file_group() {
   basename "$BATS_TEST_FILENAME" .bats
 }
 
-ffmpeg_command_path() {
+ffmpeg_log_path() {
   printf './%s\n' "$(realpath --relative-to "." "$1")"
+}
+
+ffmpeg_log_line_number() {
+  grep -nF -- "$1" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1
 }
 
 ffmpeg_processing_call_count() {
@@ -27,8 +31,4 @@ ffmpeg_processing_call_count() {
 
 ffmpeg_acceleration_call_count() {
   grep -F -- "-filter_complex" "$FFMPEG_LOG_FILE" | wc -l | tr -d " "
-}
-
-ffmpeg_log_line_number() {
-  grep -nF -- "$1" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1
 }

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -2,13 +2,15 @@
 
 load test_helper
 
-@test "[$(test_file_group)] --speed-factor and -s accelerate non-target FPS videos after FPS fixing" {
+@test "[$(test_file_group)] -s and --speed-factor accelerate non-target FPS videos after FPS fixing" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/video.mp4"
-  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
-  declare -r accelerated_video="$input_dir/fixed-videos/video.60_fps.1.5x.mp4"
 
-  for speed_option in --speed-factor -s; do
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
+  declare -r accelerated_video="$fixed_videos_dir/video.60_fps.1.5x.mp4"
+
+  for speed_option in -s --speed-factor; do
     rm -rf "$input_dir"
     truncate -s 0 "$FFMPEG_LOG_FILE"
 
@@ -37,46 +39,60 @@ load test_helper
   done
 }
 
-@test "[$(test_file_group)] --speed-factor skips already target FPS videos without --force and does not accelerate" {
+@test "[$(test_file_group)] -s and --speed-factor skip already target FPS videos without --force and do not accelerate" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/video.mp4"
-  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
-  declare -r accelerated_video="$input_dir/fixed-videos/video.60_fps.1.5x.mp4"
 
-  mkdir -p "$input_dir"
-  touch "$video"
-  printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
+  declare -r accelerated_video="$fixed_videos_dir/video.60_fps.1.5x.mp4"
 
-  run "$SCRIPT" --speed-factor 1.5 "$input_dir"
-  [ "$status" -eq 0 ]
-  [ ! -f "$fixed_video" ]
-  [ ! -f "$accelerated_video" ]
-  [ "$(ffmpeg_processing_call_count)" -eq 0 ]
-  [ "$(ffmpeg_acceleration_call_count)" -eq 0 ]
-  ! grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
-  ! grep -F -- "-filter_complex" "$FFMPEG_LOG_FILE"
+  for speed_option in -s --speed-factor; do
+    rm -rf "$input_dir"
+    truncate -s 0 "$FFMPEG_LOG_FILE"
+
+    mkdir -p "$input_dir"
+    touch "$video"
+    printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+    run "$SCRIPT" "$speed_option" 1.5 "$input_dir"
+    [ "$status" -eq 0 ]
+    [ ! -f "$fixed_video" ]
+    [ ! -f "$accelerated_video" ]
+    [ "$(ffmpeg_processing_call_count)" -eq 0 ]
+    [ "$(ffmpeg_acceleration_call_count)" -eq 0 ]
+    ! grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+    ! grep -F -- "-filter_complex" "$FFMPEG_LOG_FILE"
+  done
 }
 
-@test "[$(test_file_group)] --speed-factor with --force does not skip already target FPS videos and accelerates" {
+@test "[$(test_file_group)] -s and --speed-factor with --force do not skip already target FPS videos and accelerate" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/video.mp4"
-  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
-  declare -r accelerated_video="$input_dir/fixed-videos/video.60_fps.1.5x.mp4"
 
-  mkdir -p "$input_dir"
-  touch "$video"
-  printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
+  declare -r accelerated_video="$fixed_videos_dir/video.60_fps.1.5x.mp4"
 
-  run "$SCRIPT" --force --speed-factor 1.5 "$input_dir"
-  [ "$status" -eq 0 ]
-  [ -f "$fixed_video" ]
-  [ -f "$accelerated_video" ]
-  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
-  [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
-  declare logged_accelerated_video="./$(realpath --relative-to "." "$accelerated_video")"
-  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
-  grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-  grep -F -- "$logged_accelerated_video" "$FFMPEG_LOG_FILE"
+  for speed_option in -s --speed-factor; do
+    rm -rf "$input_dir"
+    truncate -s 0 "$FFMPEG_LOG_FILE"
+
+    mkdir -p "$input_dir"
+    touch "$video"
+    printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+    run "$SCRIPT" "$speed_option" 1.5 --force "$input_dir"
+    [ "$status" -eq 0 ]
+    [ -f "$fixed_video" ]
+    [ -f "$accelerated_video" ]
+    [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+    [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
+    declare logged_accelerated_video="./$(realpath --relative-to "." "$accelerated_video")"
+    grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+    grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
+    grep -F -- "$logged_accelerated_video" "$FFMPEG_LOG_FILE"
+  done
 }
 
 @test "[$(test_file_group)] acceleration with audio uses video and audio filters and maps both outputs" {
@@ -98,13 +114,15 @@ load test_helper
 @test "[$(test_file_group)] acceleration with --no-audio maps only video and disables audio" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/video.mp4"
-  declare -r accelerated_video="$input_dir/fixed-videos/video.60_fps.1.5x.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r accelerated_video="$fixed_videos_dir/video.60_fps.1.5x.mp4"
 
   mkdir -p "$input_dir"
   touch "$video"
   printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
 
-  run "$SCRIPT" --speed-factor 1.5 --no-audio "$input_dir"
+  run "$SCRIPT" -s 1.5 --no-audio "$input_dir"
   [ "$status" -eq 0 ]
   [ -f "$accelerated_video" ]
   [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -24,12 +24,10 @@ load test_helper
     [ -f "$accelerated_video" ]
     [ "$(ffmpeg_processing_call_count)" -eq 1 ]
     [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
-    declare logged_fixed_video="./$(realpath --relative-to "." "$fixed_video")"
-    declare logged_accelerated_video="./$(realpath --relative-to "." "$accelerated_video")"
     grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
     grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-    grep -F -- "-i $logged_fixed_video" "$FFMPEG_LOG_FILE"
-    grep -F -- "$logged_accelerated_video" "$FFMPEG_LOG_FILE"
+    grep -F -- "-i $(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
 
     declare fps_fix_line
     declare acceleration_line
@@ -88,10 +86,9 @@ load test_helper
     [ -f "$accelerated_video" ]
     [ "$(ffmpeg_processing_call_count)" -eq 1 ]
     [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
-    declare logged_accelerated_video="./$(realpath --relative-to "." "$accelerated_video")"
     grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
     grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-    grep -F -- "$logged_accelerated_video" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
   done
 }
 

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "[$(test_file_group)] --speed-factor and -s accelerate non-target FPS videos after FPS fixing" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/video.mp4"
+  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
+  declare -r accelerated_video="$input_dir/fixed-videos/video.60_fps.1.5x.mp4"
+
+  for speed_option in --speed-factor -s; do
+    rm -rf "$input_dir"
+    truncate -s 0 "$FFMPEG_LOG_FILE"
+
+    mkdir -p "$input_dir"
+    touch "$video"
+    printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+    run "$SCRIPT" "$speed_option" 1.5 "$input_dir"
+    [ "$status" -eq 0 ]
+    [ -f "$fixed_video" ]
+    [ -f "$accelerated_video" ]
+    [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+    [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
+    declare logged_fixed_video="./$(realpath --relative-to "." "$fixed_video")"
+    declare logged_accelerated_video="./$(realpath --relative-to "." "$accelerated_video")"
+    grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+    grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
+    grep -F -- "-i $logged_fixed_video" "$FFMPEG_LOG_FILE"
+    grep -F -- "$logged_accelerated_video" "$FFMPEG_LOG_FILE"
+
+    declare fps_fix_line
+    declare acceleration_line
+    fps_fix_line="$(grep -nF -- "-filter:v fps=60" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
+    acceleration_line="$(grep -nF -- "-filter_complex" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
+    [ "$fps_fix_line" -lt "$acceleration_line" ]
+  done
+}
+
+@test "[$(test_file_group)] --speed-factor skips already target FPS videos without --force and does not accelerate" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/video.mp4"
+  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
+  declare -r accelerated_video="$input_dir/fixed-videos/video.60_fps.1.5x.mp4"
+
+  mkdir -p "$input_dir"
+  touch "$video"
+  printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --speed-factor 1.5 "$input_dir"
+  [ "$status" -eq 0 ]
+  [ ! -f "$fixed_video" ]
+  [ ! -f "$accelerated_video" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 0 ]
+  [ "$(ffmpeg_acceleration_call_count)" -eq 0 ]
+  ! grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "-filter_complex" "$FFMPEG_LOG_FILE"
+}
+
+@test "[$(test_file_group)] --speed-factor with --force does not skip already target FPS videos and accelerates" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/video.mp4"
+  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
+  declare -r accelerated_video="$input_dir/fixed-videos/video.60_fps.1.5x.mp4"
+
+  mkdir -p "$input_dir"
+  touch "$video"
+  printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --force --speed-factor 1.5 "$input_dir"
+  [ "$status" -eq 0 ]
+  [ -f "$fixed_video" ]
+  [ -f "$accelerated_video" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
+  declare logged_accelerated_video="./$(realpath --relative-to "." "$accelerated_video")"
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
+  grep -F -- "$logged_accelerated_video" "$FFMPEG_LOG_FILE"
+}
+
+@test "[$(test_file_group)] acceleration with audio uses video and audio filters and maps both outputs" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/video.mp4"
+
+  mkdir -p "$input_dir"
+  touch "$video"
+  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --speed-factor 1.5 "$input_dir"
+  [ "$status" -eq 0 ]
+  [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
+  grep -F -- "setpts=PTS/1.5[v]" "$FFMPEG_LOG_FILE"
+  grep -F -- "atempo=1.5[a]" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map [v] -map [a]" "$FFMPEG_LOG_FILE"
+}
+
+@test "[$(test_file_group)] acceleration with --no-audio maps only video and disables audio" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r video="$input_dir/video.mp4"
+  declare -r accelerated_video="$input_dir/fixed-videos/video.60_fps.1.5x.mp4"
+
+  mkdir -p "$input_dir"
+  touch "$video"
+  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+  run "$SCRIPT" --speed-factor 1.5 --no-audio "$input_dir"
+  [ "$status" -eq 0 ]
+  [ -f "$accelerated_video" ]
+  [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
+  grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v]" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "atempo" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map [v] -an" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "-map [a]" "$FFMPEG_LOG_FILE"
+  grep -F -- "-an" "$FFMPEG_LOG_FILE"
+}

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -47,7 +47,7 @@ load test_helper
   done
 }
 
-@test "[$(test_file_group)] -s and --speed-factor with --force do not skip already target FPS videos and accelerate" {
+@test "[$(test_file_group)] -s and --speed-factor with --force do not skip already target FPS videos" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/video.mp4"
 
@@ -56,22 +56,28 @@ load test_helper
   declare -r accelerated_video="$fixed_videos_dir/video.60_fps.1.5x.mp4"
 
   for speed_option in -s --speed-factor; do
-    rm -rf "$input_dir"
-    truncate -s 0 "$FFMPEG_LOG_FILE"
+    for force_option in -F --force; do
+      rm -rf "$input_dir"
+      truncate -s 0 "$FFMPEG_LOG_FILE"
 
-    mkdir -p "$input_dir"
-    touch "$video"
-    printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+      mkdir -p "$input_dir"
+      touch "$video"
+      printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
 
-    run "$SCRIPT" "$speed_option" 1.5 --force "$input_dir"
-    [ "$status" -eq 0 ]
-    [ -f "$fixed_video" ]
-    [ -f "$accelerated_video" ]
-    [ "$(ffmpeg_processing_call_count)" -eq 1 ]
-    [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
-    grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
-    grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
+      run "$SCRIPT" "$speed_option" 1.5 "$force_option" "$input_dir"
+      [ "$status" -eq 0 ]
+      [ -f "$fixed_video" ]
+      [ -f "$accelerated_video" ]
+      [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+      [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
+      ! grep -x -- "-i $video" "$FFMPEG_LOG_FILE" # ensures the standalone probe command is absent
+      grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+      grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
+      grep -F -- "-map [v] -map [a]" "$FFMPEG_LOG_FILE"
+      grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+      grep -F -- "-i $(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+      grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
+    done
   done
 }
 

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -34,14 +34,16 @@ load test_helper
     [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
     grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
     grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-    grep -F -- "-i $(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$non_target_fps_accelerated_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "-map [v] -map [a]" "$FFMPEG_LOG_FILE"
     ! grep -F -- "$(ffmpeg_command_path "$target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
     ! grep -F -- "$(ffmpeg_command_path "$target_fps_accelerated_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "-i $(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$non_target_fps_accelerated_video")" "$FFMPEG_LOG_FILE"
 
-    declare fps_fix_line="$(grep -nF -- "-filter:v fps=60" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
-    declare acceleration_line="$(grep -nF -- "-filter_complex" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
-    [ "$fps_fix_line" -lt "$acceleration_line" ]
+    declare fps_fix_line="$(ffmpeg_log_line_number "-filter:v fps=60")"
+    declare fps_acceleration_line="$(ffmpeg_log_line_number "-filter_complex")"
+    [ "$fps_fix_line" -lt "$fps_acceleration_line" ]
   done
 }
 
@@ -71,22 +73,6 @@ load test_helper
     grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
     grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
   done
-}
-
-@test "[$(test_file_group)] acceleration with audio uses video and audio filters and maps both outputs" {
-  declare -r input_dir="$TMPDIR_TEST/in"
-  declare -r video="$input_dir/video.mp4"
-
-  mkdir -p "$input_dir"
-  touch "$video"
-  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
-
-  run "$SCRIPT" --speed-factor 1.5 "$input_dir"
-  [ "$status" -eq 0 ]
-  [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
-  grep -F -- "setpts=PTS/1.5[v]" "$FFMPEG_LOG_FILE"
-  grep -F -- "atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-  grep -F -- "-map [v] -map [a]" "$FFMPEG_LOG_FILE"
 }
 
 @test "[$(test_file_group)] acceleration with --no-audio maps only video and disables audio" {

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -32,21 +32,15 @@ load test_helper
     [ -f "$non_target_fps_accelerated_video" ]
     [ "$(ffmpeg_processing_call_count)" -eq 1 ]
     [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
-    declare non_target_fps_fixed_command_path="$(ffmpeg_command_path "$non_target_fps_fixed_video")"
-    declare non_target_fps_accelerated_command_path="$(ffmpeg_command_path "$non_target_fps_accelerated_video")"
-    declare target_fps_fixed_command_path="$(ffmpeg_command_path "$target_fps_fixed_video")"
-    declare target_fps_accelerated_command_path="$(ffmpeg_command_path "$target_fps_accelerated_video")"
     grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
     grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-    grep -F -- "-i $non_target_fps_fixed_command_path" "$FFMPEG_LOG_FILE"
-    grep -F -- "$non_target_fps_accelerated_command_path" "$FFMPEG_LOG_FILE"
-    ! grep -F -- "$target_fps_fixed_command_path" "$FFMPEG_LOG_FILE"
-    ! grep -F -- "$target_fps_accelerated_command_path" "$FFMPEG_LOG_FILE"
+    grep -F -- "-i $(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$non_target_fps_accelerated_video")" "$FFMPEG_LOG_FILE"
+    ! grep -F -- "$(ffmpeg_command_path "$target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+    ! grep -F -- "$(ffmpeg_command_path "$target_fps_accelerated_video")" "$FFMPEG_LOG_FILE"
 
-    declare fps_fix_line
-    declare acceleration_line
-    fps_fix_line="$(grep -nF -- "-filter:v fps=60" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
-    acceleration_line="$(grep -nF -- "-filter_complex" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
+    declare fps_fix_line="$(grep -nF -- "-filter:v fps=60" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
+    declare acceleration_line="$(grep -nF -- "-filter_complex" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
     [ "$fps_fix_line" -lt "$acceleration_line" ]
   done
 }
@@ -75,8 +69,7 @@ load test_helper
     [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
     grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
     grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-    declare accelerated_command_path="$(ffmpeg_command_path "$accelerated_video")"
-    grep -F -- "$accelerated_command_path" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
   done
 }
 

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -81,24 +81,35 @@ load test_helper
   done
 }
 
-@test "[$(test_file_group)] acceleration with --no-audio maps only video and disables audio" {
+@test "[$(test_file_group)] -s and --speed-factor with --no-audio maps only video and disables audio" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r video="$input_dir/video.mp4"
 
   declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
   declare -r accelerated_video="$fixed_videos_dir/video.60_fps.1.5x.mp4"
 
-  mkdir -p "$input_dir"
-  touch "$video"
-  printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+  for speed_option in -s --speed-factor; do
+    rm -rf "$input_dir"
+    truncate -s 0 "$FFMPEG_LOG_FILE"
 
-  run "$SCRIPT" -s 1.5 --no-audio "$input_dir"
-  [ "$status" -eq 0 ]
-  [ -f "$accelerated_video" ]
-  [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
-  grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v]" "$FFMPEG_LOG_FILE"
-  ! grep -F -- "atempo" "$FFMPEG_LOG_FILE"
-  grep -F -- "-map [v] -an" "$FFMPEG_LOG_FILE"
-  ! grep -F -- "-map [a]" "$FFMPEG_LOG_FILE"
-  grep -F -- "-an" "$FFMPEG_LOG_FILE"
+    mkdir -p "$input_dir"
+    touch "$video"
+    printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+
+    run "$SCRIPT" "$speed_option" 1.5 --no-audio "$input_dir"
+    [ "$status" -eq 0 ]
+    [ -f "$fixed_video" ]
+    [ -f "$accelerated_video" ]
+    [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+    [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
+    grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+    grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v]" "$FFMPEG_LOG_FILE"
+    ! grep -F -- "atempo" "$FFMPEG_LOG_FILE"
+    grep -F -- "-map [v] -an" "$FFMPEG_LOG_FILE"
+    ! grep -F -- "-map [a]" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "-i $(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
+  done
 }

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -35,11 +35,11 @@ load test_helper
     grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
     grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
     grep -F -- "-map [v] -map [a]" "$FFMPEG_LOG_FILE"
-    ! grep -F -- "$(ffmpeg_command_path "$target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
-    ! grep -F -- "$(ffmpeg_command_path "$target_fps_accelerated_video")" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
-    grep -F -- "-i $(ffmpeg_command_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$non_target_fps_accelerated_video")" "$FFMPEG_LOG_FILE"
+    ! grep -F -- "$(ffmpeg_log_path "$target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+    ! grep -F -- "$(ffmpeg_log_path "$target_fps_accelerated_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_log_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "-i $(ffmpeg_log_path "$non_target_fps_fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_log_path "$non_target_fps_accelerated_video")" "$FFMPEG_LOG_FILE"
 
     declare fps_fix_line="$(ffmpeg_log_line_number "-filter:v fps=60")"
     declare fps_acceleration_line="$(ffmpeg_log_line_number "-filter_complex")"
@@ -74,9 +74,9 @@ load test_helper
       grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
       grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
       grep -F -- "-map [v] -map [a]" "$FFMPEG_LOG_FILE"
-      grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
-      grep -F -- "-i $(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
-      grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
+      grep -F -- "$(ffmpeg_log_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+      grep -F -- "-i $(ffmpeg_log_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+      grep -F -- "$(ffmpeg_log_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
     done
   done
 }
@@ -108,8 +108,8 @@ load test_helper
     ! grep -F -- "atempo" "$FFMPEG_LOG_FILE"
     grep -F -- "-map [v] -an" "$FFMPEG_LOG_FILE"
     ! grep -F -- "-map [a]" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
-    grep -F -- "-i $(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_log_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "-i $(ffmpeg_log_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "$(ffmpeg_log_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
   done
 }

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -2,65 +2,52 @@
 
 load test_helper
 
-@test "[$(test_file_group)] -s and --speed-factor accelerate non-target FPS videos after FPS fixing" {
+@test "[$(test_file_group)] -s and --speed-factor accelerate only non-target FPS videos after FPS fixing" {
   declare -r input_dir="$TMPDIR_TEST/in"
-  declare -r video="$input_dir/video.mp4"
+  declare -r target_fps_video="$input_dir/target.mp4"
+  declare -r non_target_fps_video="$input_dir/fix.mp4"
 
   declare -r fixed_videos_dir="$input_dir/fixed-videos"
-  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
-  declare -r accelerated_video="$fixed_videos_dir/video.60_fps.1.5x.mp4"
+  declare -r target_fps_fixed_video="$fixed_videos_dir/target.60_fps.mp4"
+  declare -r target_fps_accelerated_video="$fixed_videos_dir/target.60_fps.1.5x.mp4"
+  declare -r non_target_fps_fixed_video="$fixed_videos_dir/fix.60_fps.mp4"
+  declare -r non_target_fps_accelerated_video="$fixed_videos_dir/fix.60_fps.1.5x.mp4"
 
   for speed_option in -s --speed-factor; do
     rm -rf "$input_dir"
     truncate -s 0 "$FFMPEG_LOG_FILE"
 
     mkdir -p "$input_dir"
-    touch "$video"
-    printf '%s|50\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
+    touch "$target_fps_video" "$non_target_fps_video"
+    {
+      printf '%s|60\n' "$target_fps_video"
+      printf '%s|50\n' "$non_target_fps_video"
+    } > "$FFMPEG_FPS_MAP_FILE"
 
     run "$SCRIPT" "$speed_option" 1.5 "$input_dir"
     [ "$status" -eq 0 ]
-    [ -f "$fixed_video" ]
-    [ -f "$accelerated_video" ]
+    [ ! -f "$target_fps_fixed_video" ]
+    [ ! -f "$target_fps_accelerated_video" ]
+    [ -f "$non_target_fps_fixed_video" ]
+    [ -f "$non_target_fps_accelerated_video" ]
     [ "$(ffmpeg_processing_call_count)" -eq 1 ]
     [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
+    declare non_target_fps_fixed_command_path="$(ffmpeg_command_path "$non_target_fps_fixed_video")"
+    declare non_target_fps_accelerated_command_path="$(ffmpeg_command_path "$non_target_fps_accelerated_video")"
+    declare target_fps_fixed_command_path="$(ffmpeg_command_path "$target_fps_fixed_video")"
+    declare target_fps_accelerated_command_path="$(ffmpeg_command_path "$target_fps_accelerated_video")"
     grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
     grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-    grep -F -- "-i $(ffmpeg_command_path "$fixed_video")" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
+    grep -F -- "-i $non_target_fps_fixed_command_path" "$FFMPEG_LOG_FILE"
+    grep -F -- "$non_target_fps_accelerated_command_path" "$FFMPEG_LOG_FILE"
+    ! grep -F -- "$target_fps_fixed_command_path" "$FFMPEG_LOG_FILE"
+    ! grep -F -- "$target_fps_accelerated_command_path" "$FFMPEG_LOG_FILE"
 
     declare fps_fix_line
     declare acceleration_line
     fps_fix_line="$(grep -nF -- "-filter:v fps=60" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
     acceleration_line="$(grep -nF -- "-filter_complex" "$FFMPEG_LOG_FILE" | cut -d: -f1 | head -n1)"
     [ "$fps_fix_line" -lt "$acceleration_line" ]
-  done
-}
-
-@test "[$(test_file_group)] -s and --speed-factor skip already target FPS videos without --force and do not accelerate" {
-  declare -r input_dir="$TMPDIR_TEST/in"
-  declare -r video="$input_dir/video.mp4"
-
-  declare -r fixed_videos_dir="$input_dir/fixed-videos"
-  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
-  declare -r accelerated_video="$fixed_videos_dir/video.60_fps.1.5x.mp4"
-
-  for speed_option in -s --speed-factor; do
-    rm -rf "$input_dir"
-    truncate -s 0 "$FFMPEG_LOG_FILE"
-
-    mkdir -p "$input_dir"
-    touch "$video"
-    printf '%s|60\n' "$video" > "$FFMPEG_FPS_MAP_FILE"
-
-    run "$SCRIPT" "$speed_option" 1.5 "$input_dir"
-    [ "$status" -eq 0 ]
-    [ ! -f "$fixed_video" ]
-    [ ! -f "$accelerated_video" ]
-    [ "$(ffmpeg_processing_call_count)" -eq 0 ]
-    [ "$(ffmpeg_acceleration_call_count)" -eq 0 ]
-    ! grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
-    ! grep -F -- "-filter_complex" "$FFMPEG_LOG_FILE"
   done
 }
 
@@ -88,7 +75,8 @@ load test_helper
     [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
     grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
     grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
-    grep -F -- "$(ffmpeg_command_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
+    declare accelerated_command_path="$(ffmpeg_command_path "$accelerated_video")"
+    grep -F -- "$accelerated_command_path" "$FFMPEG_LOG_FILE"
   done
 }
 


### PR DESCRIPTION
### Motivation
- Cover video acceleration behavior (`--speed-factor` / `-s`) to ensure acceleration runs after FPS-fixing and that skip/force logic is correct for videos already at target FPS.
- Validate accelerated output filename format and ffmpeg filter/map usage for both audio and `--no-audio` cases.

### Description
- Add a new Bats test file `test/video_acceleration.bats` with tests that cover: acceleration ordering (FPS fixing before acceleration), both long and short speed options (`--speed-factor` and `-s`), skipping behavior when input already has target FPS without `--force`, forcing behavior with `--force`, accelerated filename suffix like `video.60_fps.1.5x.mp4`, audio acceleration using `setpts` + `atempo` and mapping both `[v]` and `[a]`, and `--no-audio` behavior which omits `atempo`, maps only `[v]` and adds `-an`.
- Add `ffmpeg_acceleration_call_count()` to `test/test_helper.bash` to let tests count acceleration invocations by grepping `-filter_complex` in the mocked ffmpeg log.

### Testing
- Ran a shell syntax check with `bash -n fps_fixer.bash test/test_helper.bash test/bin/ffmpeg test/video_acceleration.bats` which passed (no syntax errors).
- Executed automated smoke runs invoking `./fps_fixer.bash` against the mocked `test/bin/ffmpeg` and inspected `FFMPEG_LOG_FILE` to verify acceleration and no-audio behaviors; those checks succeeded in the environment.
- Attempted to run the full Bats suite (`bats test` / `npx --yes bats test`) but `bats` was not available and installing it via npm or apt failed due to external registry/repository 403 errors, so the Bats runner could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2334f593d0832b8656e8f97aee48fc)

Issue: #12