### PR TITLE
Fix single-file input output path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Options:
 - `-v`, `--version` &mdash; show the version;
 - `-h`, `--help` &mdash; show the help;
 - `-e EXTENSION`, `--extension EXTENSION` &mdash; video file extension (default: `mp4`);
-- `-b PATH`, `--base-path PATH` &mdash; base path for fixed videos (relative to the input directory, or to the input file's parent directory when `<path>` is a single file; default: `./fixed-videos`);
+- `-b PATH`, `--base-path PATH` &mdash; base path for fixed videos (relative to the input directory or single file's parent directory; default: `./fixed-videos`);
 - `-f FPS`, `--fps FPS` &mdash; target FPS (default: `60`);
 - `-E EPSILON`, `--epsilon EPSILON` &mdash; allowable error when comparing FPS (default: `2`);
 - `-F`, `--force` &mdash; process every video regardless of FPS check;
@@ -55,7 +55,7 @@ Options:
 
 Arguments:
 
-- `<path>` &mdash; directory containing original videos, or a single original video file matching the selected extension (default: `.`).
+- `<path>` &mdash; directory containing original videos or a single original video file (default: `.`).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Options:
 - `-v`, `--version` &mdash; show the version;
 - `-h`, `--help` &mdash; show the help;
 - `-e EXTENSION`, `--extension EXTENSION` &mdash; video file extension (default: `mp4`);
-- `-b PATH`, `--base-path PATH` &mdash; base path for fixed videos (should be relative to argument `<path>`; default: `./fixed-videos`);
+- `-b PATH`, `--base-path PATH` &mdash; base path for fixed videos (relative to the input directory, or to the input file's parent directory when `<path>` is a single file; default: `./fixed-videos`);
 - `-f FPS`, `--fps FPS` &mdash; target FPS (default: `60`);
 - `-E EPSILON`, `--epsilon EPSILON` &mdash; allowable error when comparing FPS (default: `2`);
 - `-F`, `--force` &mdash; process every video regardless of FPS check;
@@ -55,7 +55,7 @@ Options:
 
 Arguments:
 
-- `<path>` &mdash; base path to original videos (default: `.`).
+- `<path>` &mdash; directory containing original videos, or a single original video file matching the selected extension (default: `.`).
 
 ## Testing
 

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -153,8 +153,7 @@ while [[ "$1" != "--" ]]; do
       echo
       echo "Arguments:"
       echo "  <path>                               - directory containing original videos" \
-        "or a single original video file matching the selected extension" \
-        "(default: \".\")."
+        "or a single original video file (default: \".\")."
 
       exit 0
       ;;

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -152,8 +152,9 @@ while [[ "$1" != "--" ]]; do
         "only search for them and check their FPS."
       echo
       echo "Arguments:"
-      echo "  <path>                               - directory containing original videos or a" \
-        "single original video file matching the selected extension (default: \".\")."
+      echo "  <path>                               - directory containing original videos" \
+        "or a single original video file matching the selected extension" \
+        "(default: \".\")."
 
       exit 0
       ;;

--- a/fps_fixer.bash
+++ b/fps_fixer.bash
@@ -139,7 +139,8 @@ while [[ "$1" != "--" ]]; do
       echo "  -h, --help                           - show the help;"
       echo "  -e EXTENSION, --extension EXTENSION  - video file extension (default: \"mp4\");"
       echo "  -b PATH, --base-path PATH            - base path for fixed videos" \
-        "(should be relative to argument \"<path>\"; default: \"./fixed-videos\");"
+        "(relative to the input directory or single file's parent directory;" \
+        "default: \"./fixed-videos\");"
       echo "  -f FPS, --fps FPS                    - target FPS (default: \"60\");"
       echo "  -E EPSILON, --epsilon EPSILON        - allowable error when comparing FPS" \
         "(default: \"2\");"
@@ -151,8 +152,8 @@ while [[ "$1" != "--" ]]; do
         "only search for them and check their FPS."
       echo
       echo "Arguments:"
-      echo "  <path>                               - base path to original videos" \
-        "(default: \".\")."
+      echo "  <path>                               - directory containing original videos or a" \
+        "single original video file matching the selected extension (default: \".\")."
 
       exit 0
       ;;
@@ -194,7 +195,11 @@ declare original_video_base_path="."
 shift # an additional shift for the "--" option
 if [[ $# == 1 ]]; then
   original_video_base_path="$1"
-  fixed_video_base_path="$original_video_base_path/$fixed_video_base_path"
+  if [[ -f "$original_video_base_path" ]]; then
+    fixed_video_base_path="$(dirname -- "$original_video_base_path")/$fixed_video_base_path"
+  else
+    fixed_video_base_path="$original_video_base_path/$fixed_video_base_path"
+  fi
 elif [[ $# > 1 ]]; then
   log ERROR "too many positional arguments"
   exit 1

--- a/test/file_discovery.bats
+++ b/test/file_discovery.bats
@@ -81,3 +81,33 @@ load test_helper
     grep -F -- "$top_level_target_mov" "$FFPROBE_LOG_FILE"
   done
 }
+
+@test "[$(test_file_group)] single-file input discovers only the selected matching file" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r selected_video="$input_dir/selected.mp4"
+  declare -r sibling_video="$input_dir/sibling.mp4"
+  declare -r non_target_video="$input_dir/selected.mov"
+
+  mkdir -p "$input_dir"
+  touch "$selected_video" "$sibling_video" "$non_target_video"
+  printf '%s|50\n' "$selected_video" > "$FFPROBE_FPS_MAP_FILE"
+
+  run "$SCRIPT" --no-process "$selected_video"
+  [ "$status" -eq 0 ]
+  grep -F -- "$selected_video" "$FFPROBE_LOG_FILE"
+  ! grep -F -- "$sibling_video" "$FFPROBE_LOG_FILE"
+  ! grep -F -- "$non_target_video" "$FFPROBE_LOG_FILE"
+}
+
+@test "[$(test_file_group)] single-file input with non-matching extension is ignored" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r selected_video="$input_dir/selected.mov"
+
+  mkdir -p "$input_dir"
+  touch "$selected_video"
+  printf '%s|50\n' "$selected_video" > "$FFPROBE_FPS_MAP_FILE"
+
+  run "$SCRIPT" --no-process "$selected_video"
+  [ "$status" -eq 0 ]
+  ! grep -F -- "$selected_video" "$FFPROBE_LOG_FILE"
+}

--- a/test/fps_fixer.bats
+++ b/test/fps_fixer.bats
@@ -33,3 +33,25 @@ load test_helper
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
   grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }
+
+@test "single-file input with selected extension and base path writes beside the input file" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r selected_video="$input_dir/video.mov"
+
+  declare -r fixed_videos_dir="$input_dir/out"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mov"
+
+  mkdir -p "$input_dir"
+  touch "$selected_video"
+  printf '%s|50\n' "$selected_video" > "$FFPROBE_FPS_MAP_FILE"
+
+  run "$SCRIPT" --extension mov --base-path out "$selected_video"
+  [ "$status" -eq 0 ]
+  [ -f "$fixed_video" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-vsync cfr" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+}

--- a/test/fps_processing.bats
+++ b/test/fps_processing.bats
@@ -247,8 +247,10 @@ load test_helper
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r selected_video="$input_dir/video.mp4"
   declare -r sibling_video="$input_dir/sibling.mp4"
-  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
-  declare -r sibling_fixed_video="$input_dir/fixed-videos/sibling.60_fps.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
+  declare -r sibling_fixed_video="$fixed_videos_dir/sibling.60_fps.mp4"
 
   mkdir -p "$input_dir"
   touch "$selected_video" "$sibling_video"
@@ -262,22 +264,10 @@ load test_helper
   [ -f "$fixed_video" ]
   [ ! -f "$sibling_fixed_video" ]
   [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-vsync cfr" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
   grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
   ! grep -F -- "$sibling_video" "$FFMPEG_LOG_FILE"
-}
-
-@test "[$(test_file_group)] single-file input writes custom base path beside the input file" {
-  declare -r input_dir="$TMPDIR_TEST/in"
-  declare -r selected_video="$input_dir/video.mp4"
-  declare -r fixed_video="$input_dir/out/video.60_fps.mp4"
-
-  mkdir -p "$input_dir"
-  touch "$selected_video"
-  printf '%s|50\n' "$selected_video" > "$FFPROBE_FPS_MAP_FILE"
-
-  run "$SCRIPT" --base-path out "$selected_video"
-  [ "$status" -eq 0 ]
-  [ -f "$fixed_video" ]
-  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
-  grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }

--- a/test/fps_processing.bats
+++ b/test/fps_processing.bats
@@ -243,7 +243,7 @@ load test_helper
   grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }
 
-@test "[$(test_file_group)] single-file input writes default output beside the input file" {
+@test "[$(test_file_group)] single-file input writes processed output beside the input file" {
   declare -r input_dir="$TMPDIR_TEST/in"
   declare -r selected_video="$input_dir/video.mp4"
   declare -r sibling_video="$input_dir/sibling.mp4"
@@ -269,5 +269,5 @@ load test_helper
   grep -F -- "-map 0:v" "$FFMPEG_LOG_FILE"
   grep -F -- "-map 0:a?" "$FFMPEG_LOG_FILE"
   grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
-  ! grep -F -- "$sibling_video" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "$(relative_path "$sibling_fixed_video")" "$FFMPEG_LOG_FILE"
 }

--- a/test/fps_processing.bats
+++ b/test/fps_processing.bats
@@ -242,3 +242,42 @@ load test_helper
   grep -F -- "-an" "$FFMPEG_LOG_FILE"
   grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
 }
+
+@test "[$(test_file_group)] single-file input writes default output beside the input file" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r selected_video="$input_dir/video.mp4"
+  declare -r sibling_video="$input_dir/sibling.mp4"
+  declare -r fixed_video="$input_dir/fixed-videos/video.60_fps.mp4"
+  declare -r sibling_fixed_video="$input_dir/fixed-videos/sibling.60_fps.mp4"
+
+  mkdir -p "$input_dir"
+  touch "$selected_video" "$sibling_video"
+  {
+    printf '%s|50\n' "$selected_video"
+    printf '%s|50\n' "$sibling_video"
+  } > "$FFPROBE_FPS_MAP_FILE"
+
+  run "$SCRIPT" "$selected_video"
+  [ "$status" -eq 0 ]
+  [ -f "$fixed_video" ]
+  [ ! -f "$sibling_fixed_video" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "$sibling_video" "$FFMPEG_LOG_FILE"
+}
+
+@test "[$(test_file_group)] single-file input writes custom base path beside the input file" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r selected_video="$input_dir/video.mp4"
+  declare -r fixed_video="$input_dir/out/video.60_fps.mp4"
+
+  mkdir -p "$input_dir"
+  touch "$selected_video"
+  printf '%s|50\n' "$selected_video" > "$FFPROBE_FPS_MAP_FILE"
+
+  run "$SCRIPT" --base-path out "$selected_video"
+  [ "$status" -eq 0 ]
+  [ -f "$fixed_video" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+}

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -181,9 +181,6 @@ load test_helper
   grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
   grep -F -- "-i $(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
   grep -F -- "$(relative_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
-  ! grep -F -- "$sibling_video" "$FFMPEG_LOG_FILE"
-
-  declare fps_fix_line="$(ffmpeg_log_line_number "-filter:v fps=60")"
-  declare fps_acceleration_line="$(ffmpeg_log_line_number "-filter_complex")"
-  [ "$fps_fix_line" -lt "$fps_acceleration_line" ]
+  ! grep -F -- "$(relative_path "$sibling_fixed_video")" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "$(relative_path "$sibling_accelerated_video")" "$FFMPEG_LOG_FILE"
 }

--- a/test/video_acceleration.bats
+++ b/test/video_acceleration.bats
@@ -148,3 +148,42 @@ load test_helper
     grep -F -- "$(relative_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
   done
 }
+
+@test "[$(test_file_group)] single-file input writes accelerated output beside the input file" {
+  declare -r input_dir="$TMPDIR_TEST/in"
+  declare -r selected_video="$input_dir/video.mp4"
+  declare -r sibling_video="$input_dir/sibling.mp4"
+
+  declare -r fixed_videos_dir="$input_dir/fixed-videos"
+  declare -r fixed_video="$fixed_videos_dir/video.60_fps.mp4"
+  declare -r accelerated_video="$fixed_videos_dir/video.60_fps.1.5x.mp4"
+  declare -r sibling_fixed_video="$fixed_videos_dir/sibling.60_fps.mp4"
+  declare -r sibling_accelerated_video="$fixed_videos_dir/sibling.60_fps.1.5x.mp4"
+
+  mkdir -p "$input_dir"
+  touch "$selected_video" "$sibling_video"
+  {
+    printf '%s|50\n' "$selected_video"
+    printf '%s|50\n' "$sibling_video"
+  } > "$FFPROBE_FPS_MAP_FILE"
+
+  run "$SCRIPT" --speed-factor 1.5 "$selected_video"
+  [ "$status" -eq 0 ]
+  [ -f "$fixed_video" ]
+  [ -f "$accelerated_video" ]
+  [ ! -f "$sibling_fixed_video" ]
+  [ ! -f "$sibling_accelerated_video" ]
+  [ "$(ffmpeg_processing_call_count)" -eq 1 ]
+  [ "$(ffmpeg_acceleration_call_count)" -eq 1 ]
+  grep -F -- "-filter:v fps=60" "$FFMPEG_LOG_FILE"
+  grep -F -- "-filter_complex [0:v]setpts=PTS/1.5[v];[0:a]atempo=1.5[a]" "$FFMPEG_LOG_FILE"
+  grep -F -- "-map [v] -map [a]" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+  grep -F -- "-i $(relative_path "$fixed_video")" "$FFMPEG_LOG_FILE"
+  grep -F -- "$(relative_path "$accelerated_video")" "$FFMPEG_LOG_FILE"
+  ! grep -F -- "$sibling_video" "$FFMPEG_LOG_FILE"
+
+  declare fps_fix_line="$(ffmpeg_log_line_number "-filter:v fps=60")"
+  declare fps_acceleration_line="$(ffmpeg_log_line_number "-filter_complex")"
+  [ "$fps_fix_line" -lt "$fps_acceleration_line" ]
+}


### PR DESCRIPTION
### Motivation
- Passing a single video file as `<path>` produced an invalid output directory under the file path (e.g. `/tmp/one.mp4/fixed-videos`) because the script always treated the positional argument as a directory. 
- The change preserves existing directory-based behavior while making single-file input produce outputs beside the file (or under a custom `--base-path` relative to the file's parent). 

### Description
- Detect if the positional `<path>` is a regular file in `fps_fixer.bash` and, if so, set the fixed-video base path relative to `dirname` of the input file instead of the file path itself. 
- Update the CLI help text in `fps_fixer.bash` and the usage text in `README.md` to document that `<path>` can be a directory or a single video file and clarify `--base-path` semantics. 
- Add unit/integration tests covering single-file discovery and processing behaviors in `test/file_discovery.bats` and `test/fps_processing.bats`. 

### Testing
- Ran syntax/quick checks: `bash -n fps_fixer.bash test/*.bats test/bin/ffmpeg test/bin/ffprobe`, which succeeded. 
- Verified help output with `./fps_fixer.bash --help` and confirmed updated help text, which succeeded. 
- Performed mock-based smoke tests using the repo `test/bin/ffmpeg` and a temporary `bc` shim to validate single-file default output and single-file `--base-path` behavior, and both succeeded. 
- Ran `git diff --check` to ensure no whitespace/patch issues, which succeeded. 
- Could not run the full `bats test` suite because `bats` and `bc` are not available in the container and `apt-get install` was blocked by the environment (403), so the added Bats tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d77e21664832bbbca014f0cd9196f)

Issue: #27